### PR TITLE
contrib: CoA data comparison tool and fail-closed edges import

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ reference/       Curated screenshots + Lua/opcode reference text
 area-52/         Area-52 "Free-Pick" realm-flavour specifics (see its README)
 contrib/         Tools contributed by others, adapted (see each README)
   AscensionRedirect/            WinDivert packet redirect + Frida auth-send probe
+  CoADataComparison/            Read-only CA/community comparison + synthetic tests
 ```
+
+[`contrib/CoADataComparison`](contrib/CoADataComparison/README.md) compares
+locally supplied CA and community exports by identifiers and source hashes.
+It is an optional research tool, not a server component or a client-data bundle.
 
 ## Requirements
 

--- a/contrib/CoADataComparison/CONTRIBUTION-PROPOSAL.md
+++ b/contrib/CoADataComparison/CONTRIBUTION-PROPOSAL.md
@@ -30,7 +30,7 @@ Source references:
 | Unmapped or ambiguous community references | 43 |
 | Dangling community node references | 8 |
 
-These were independently recomputed during the initial audit. The new tool must reproduce them before release; its test and real-corpus receipts are recorded separately.
+These were independently recomputed during the initial audit and are shipped as identifier lists in `data/comparison-ids.json` (no Hub/client wording).
 
 ## Interpretation boundaries
 

--- a/contrib/CoADataComparison/CONTRIBUTION-PROPOSAL.md
+++ b/contrib/CoADataComparison/CONTRIBUTION-PROPOSAL.md
@@ -1,0 +1,60 @@
+# Proposal: reproducible CoA coverage comparison, without redistributing client content
+
+Status: draft pull request for maintainer review; not merged.
+
+Baseline: hertigservices/Ascension_preservation at `664f2768f0695187349fc38842eae6a1588cc352`.
+
+## Proposed first contribution
+
+A standalone, standard-library Python comparison tool plus synthetic tests. Collaborators supply their own local CA export and archived CoA Build Hub data. The tool reports source hashes, identifier overlap, description availability and community-versus-runtime dependency differences without copying descriptions, HTML tooltips, icons, client files, usernames, or machine-local paths into its report.
+
+This is an evidence comparison, not an importer. It never rewrites the engine CA export or substitutes community dependencies for runtime ConnectedNodes. The revision argument is labeled a caller assertion; content hashes bind the files actually read.
+
+Source references:
+- Preservation engine schema: https://github.com/hertigservices/Ascension_preservation/blob/664f2768f0695187349fc38842eae6a1588cc352/data/ca-export/SCHEMA.md
+- Community source: https://coabuildhub.com
+- Skill source recorded by the archived Hub README: https://db.ascension.gg
+- Hub archive date recorded by that README: 2026-07-31. This is archive provenance, not a fresh crawl or validation of current site terms.
+
+## Verified baseline findings motivating the proposal
+
+| Comparison | Result |
+|---|---:|
+| Hub master unique spell IDs | 5,172 |
+| IDs present in any of five CA rank fields | 3,601 |
+| IDs absent from those CA fields | 1,571 |
+| CA rows lacking both descriptions with a nonempty Hub description by primary spell ID | 3,600 |
+| Community dependency references matching runtime edges | 4,809 |
+| Community dependency references mapped to candidate differences | 142 |
+| Candidate differences remaining inside the same CA class/tab | 134 |
+| Unmapped or ambiguous community references | 43 |
+| Dangling community node references | 8 |
+
+These were independently recomputed during the initial audit. The new tool must reproduce them before release; its test and real-corpus receipts are recorded separately.
+
+## Interpretation boundaries
+
+- The 1,571 IDs are absent from the advancement export, not necessarily from the client. Classify them as supporting/trigger, historical/versioned, advancement candidate, or unresolved before considering import.
+- The 3,600 joins establish description availability, not correct current wording or permission to copy it. They remain proposals until version, class context, source attribution and rights are reviewed.
+- Dependency joins use uniquely mapped primary spell IDs. Matching IDs alone do not establish semantic equivalence. Eight candidate differences cross class/tab boundaries; even the 134 same-boundary candidates need review.
+- Runtime edges retain stronger runtime provenance than a community web representation. No authoritative edges are added by this contribution.
+- Local client snapshots checked during research do not contain the existing dangling targets 6451, 7181 or 17567. This proposal does not claim to recover them.
+
+## Suggested review order
+
+1. Review the tool, synthetic fixtures, output schema and absence of client-content redistribution.
+2. Reproduce it locally using the maintainer's own data, retaining source hashes.
+3. Review a small sample of ID-level classifications before any description-content proposal.
+4. Consider a separate narrow graph-import validation fix; keep it independent of data enrichment.
+5. Discuss the availability of historical DBC/world-cache inventories separately. Do not attach raw datasets to a public issue or PR.
+
+## Separate reproducibility follow-ups
+
+The initial audit identified original-machine data paths, sibling-module import assumptions, obsolete offline-test calls and stale integration packet-order assumptions. Those require isolated fixtures before server-related tests can safely run. They are not silently bundled into the comparison tool or treated as already repaired.
+
+The tool does not attempt authentication, client-memory reads, packet capture, network interception, database imports, or server startup. No new dependency or paid service is required.
+
+## Publication boundary
+
+This draft includes aggregate findings and original analysis only. It makes no claim that publicly accessible community text has unrestricted redistribution rights. The candidate package must exclude raw client/Hub data, generated real-corpus reports, private inventories and internal execution logs. Submission should retain the upstream license/notice for any included upstream-derived patch.
+

--- a/contrib/CoADataComparison/README.md
+++ b/contrib/CoADataComparison/README.md
@@ -1,0 +1,57 @@
+# contrib/CoADataComparison — read-only CA / community-data comparison
+
+An optional research instrument, **not part of the runnable server stack**. It compares the engine Character-Advancement export with a locally held CoA Build Hub archive without importing client content or replacing runtime evidence.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `compare_ca.py` | Standard-library command-line comparator |
+| `test_compare_ca.py` | Synthetic fixtures and automated tests; no client install required |
+| `CONTRIBUTION-PROPOSAL.md` | Scope, initial coverage findings, source attribution and review limits |
+
+## Inputs
+
+Supply your own data. Nothing is downloaded.
+
+- `--ca-root`: directory containing `entries.json` and `edges.json`, in the formats used by [`data/ca-export`](../../data/ca-export/SCHEMA.md).
+- `--hub-root`: an archived Build Hub export containing `classes.json`, `spells/master_index.json`, and the per-class `skills/<slug>.json` and `talents/<slug>.json` files. The archive uses a class list with `slug`, skill lists with `count`/`skills`, and talent trees with node IDs and dependency references. This is not the loose client `CharacterAdvancementData.json` schema.
+- `--upstream-revision`: full 40-character Git revision identifying the intended baseline. This value is a **caller assertion**, not verification that the export came from that revision. Per-file SHA-256 values identify the actual bytes read.
+- `--output`: a new JSON report outside both input roots. Existing outputs must not be overwritten.
+
+From the repository root, with Python 3.11 or later:
+
+```sh
+python contrib/CoADataComparison/compare_ca.py --ca-root data/ca-export --hub-root /path/to/private/hub-archive --upstream-revision 664f2768f0695187349fc38842eae6a1588cc352 --output /path/to/private/reports/ca-comparison.json
+```
+
+Use quoted local paths where needed. Keep generated real-data reports outside the repository. Do not put private inputs under this contribution directory.
+
+## Output and interpretation
+
+The report contains numeric identifier comparisons, availability counts, source fingerprints and explicitly labeled dependency hypotheses. It does **not** export description text, HTML tooltips, icons, names or absolute local source paths. It does not rewrite either dataset.
+
+- Rank overlap means present in one of the five CA spell-ID fields, not present in every client table.
+- Description enrichment means the CA row lacks both descriptions and a matched community primary-spell record has text. It does not validate the text's accuracy, version or redistribution rights.
+- Dependency mapping requires a unique primary-spell match. Ambiguous and dangling references remain visible instead of being silently assigned.
+- Community talent node IDs are four unsigned integers separated by hyphens, optionally followed by one lowercase letter for stacked ranks (for example `12-87-1-0` or `12-87-0-5a`). Other identifier shapes are rejected.
+- A community edge absent from the runtime graph is a **candidate discrepancy**, not an authoritative addition. Cross-class/tab discrepancies must remain separate.
+- Source revision and hashes do not establish semantic equivalence across client builds.
+
+Invalid input must produce a nonzero exit and no successful report. This tool is intentionally stricter than a best-effort importer: fix malformed or duplicate identifiers at their source, rather than allowing silent loss through dictionary overwrites.
+
+## Tests
+
+```sh
+python -m unittest discover -s contrib/CoADataComparison -p 'test_*.py' -v
+```
+
+Tests construct synthetic records in temporary directories. They do not use SavedVariables, credentials, a game client, a server, a database, or network access. No third-party Python dependency is required.
+
+## Privacy, provenance and license
+
+Follow the repository's [`NOTICE.md`](../../NOTICE.md), [`LICENSE`](../../LICENSE), and [`data/MANIFEST.md`](../../data/MANIFEST.md). Original code and tests are contributed under the repository's MIT terms; that does not license third-party client/community content.
+
+Community source: https://coabuildhub.com. The archive used for the initial comparison records https://db.ascension.gg as its skills source and 2026-07-31 as its scrape date. Those are archived provenance claims, not a current crawl. The tool does not assert that every user-supplied archive has that origin/date.
+
+Do not attach raw client files, community descriptions, guides/comments, or private source archives to a public issue or PR. Review generated reports before sharing; removing content text is a risk reduction, not blanket legal clearance.

--- a/contrib/CoADataComparison/README.md
+++ b/contrib/CoADataComparison/README.md
@@ -8,7 +8,9 @@ An optional research instrument, **not part of the runnable server stack**. It c
 |---|---|
 | `compare_ca.py` | Standard-library command-line comparator |
 | `test_compare_ca.py` | Synthetic fixtures and automated tests; no client install required |
-| `CONTRIBUTION-PROPOSAL.md` | Scope, initial coverage findings, source attribution and review limits |
+| `CONTRIBUTION-PROPOSAL.md` | Scope, coverage findings, source attribution and review limits |
+| `data/comparison-ids.json` | Identifier lists from one verified comparison (no description text) |
+| `data/README.md` | How to read those lists |
 
 ## Inputs
 

--- a/contrib/CoADataComparison/compare_ca.py
+++ b/contrib/CoADataComparison/compare_ca.py
@@ -1,0 +1,220 @@
+"""Read-only, stdlib-only CA/community comparison. Outputs IDs, not source text.
+
+Community dependencies are hypotheses, never authoritative runtime additions.
+The supplied revision is a caller assertion, not verified against a checkout.
+Only the documented JSON role files are opened; no imported corpus code runs.
+"""
+import argparse
+from collections import defaultdict
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+
+
+class InvalidInput(ValueError):
+    """A deliberately content-free validation failure."""
+
+
+def require(condition):
+    if not condition:
+        raise InvalidInput('invalid schema')
+
+
+def integer(value):
+    require(type(value) is int and value >= 0)
+    return value
+
+
+def node_id(value):
+    require(type(value) is str and re.fullmatch(r'(?:0|[1-9][0-9]*)-(?:0|[1-9][0-9]*)-(?:0|[1-9][0-9]*)-(?:0|[1-9][0-9]*)[a-z]?', value) is not None)
+    return value
+
+
+def records(value, key, validator=integer):
+    require(type(value) is list)
+    seen = set()
+    for item in value:
+        require(type(item) is dict and key in item)
+        identity = validator(item[key])
+        require(identity not in seen)
+        seen.add(identity)
+    return value
+
+
+def text_fields(item, keys):
+    for key in keys:
+        if key in item:
+            require(item[key] is None or type(item[key]) is str)
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        require(key not in result)
+        result[key] = value
+    return result
+
+
+def reject_constant(value):
+    raise InvalidInput('invalid JSON constant')
+
+
+def compare(ca_root, hub_root, revision):
+    """Return a deterministic report; never write to the input directories."""
+    require(type(revision) is str and re.fullmatch(r'[0-9a-fA-F]{40}', revision) is not None)
+    ca_root, hub_root = Path(ca_root).resolve(strict=True), Path(hub_root).resolve(strict=True)
+    sources = []
+
+    def load(root, role, relative):
+        path = root / relative
+        # Resolve redirects before reading, so allowlisted names cannot escape.
+        require(path.resolve(strict=True).is_relative_to(root))
+        raw = path.read_bytes()
+        sources.append(dict(role=role, path=relative, bytes=len(raw),
+                            sha256=hashlib.sha256(raw).hexdigest()))
+        return json.loads(raw, object_pairs_hook=unique_object, parse_constant=reject_constant)
+
+    entries = records(load(ca_root, 'ca', 'entries.json'), 'ID')
+    for entry in entries:
+        for key in ('SpellID', 'SpellID2', 'SpellID3', 'SpellID4', 'SpellID5', 'ClassTypeID', 'TabTypeID'):
+            integer(entry[key])
+        text_fields(entry, ('Description', 'Description2'))
+    runtime = load(ca_root, 'ca', 'edges.json')
+    require(type(runtime) is dict)
+    for key, values in runtime.items():
+        require(re.fullmatch(r'0|[1-9][0-9]*', key) is not None)
+        require(type(values) is list)
+        for value in values:
+            integer(value)
+        require(len(values) == len(set(values)))
+    classes = records(load(hub_root, 'hub', 'classes.json'), 'id')
+    slugs = set()
+    for cls in classes:
+        slug = cls['slug']
+        require(type(slug) is str and re.fullmatch(r'[a-z][a-z0-9]*(?:-[a-z0-9]+)*', slug) is not None)
+        require(slug not in slugs)
+        slugs.add(slug)
+    master = records(load(hub_root, 'hub', 'spells/master_index.json'), 'id')
+    for item in master:
+        text_fields(item, ('description',))
+    nodes = []
+    skills = []
+    for cls in classes:
+        skill = load(hub_root, 'hub', 'skills/' + cls['slug'] + '.json')
+        talent = load(hub_root, 'hub', 'talents/' + cls['slug'] + '.json')
+        require(type(skill) is dict and type(talent) is dict)
+        require(integer(skill['classId']) == cls['id'])
+        skill_rows = records(skill['skills'], 'id')
+        require(integer(skill['count']) == len(skill_rows))
+        trees = records(talent['trees'], 'tabId')
+        class_nodes = []
+        for tree in trees:
+            tree_nodes = records(tree['nodes'], 'id', node_id)
+            require(integer(tree['nodeCount']) == len(tree_nodes))
+            for node in tree_nodes:
+                integer(node['spellId'])
+                deps = node.get('dependencies', [])
+                require(type(deps) is list)
+                for dep in deps:
+                    node_id(dep)
+                require(len(deps) == len(set(deps)))
+            class_nodes.extend(tree_nodes)
+        require(integer(talent['nodeCount']) == len(class_nodes))
+        skills.extend(skill_rows)
+        nodes.extend(class_nodes)
+    records(nodes, 'id', node_id)
+    primary = defaultdict(list)
+    ranks = defaultdict(list)
+    for entry in entries:
+        primary[entry['SpellID']].append(entry)
+        for rank in range(1, 6):
+            spell = entry['SpellID' + (str(rank) if rank > 1 else '')]
+            if spell:
+                ranks[spell].append(dict(ca_id=entry['ID'], rank=rank))
+    mids = {m['id'] for m in master}
+    descriptions = {m['id'] for m in master if m.get('description')}
+    enrich = sorted((dict(ca_id=e['ID'], spell_id=e['SpellID']) for e in entries
+                     if not e.get('Description') and not e.get('Description2')
+                     and e['SpellID'] in descriptions), key=lambda e: e['ca_id'])
+    pairs = {(int(a), b) for a, bs in runtime.items() for b in bs}
+    node_map = {n['id']: n for n in nodes}
+    counts = dict(present_runtime_edge=0, candidate_not_runtime_edge=0,
+                  candidates_same_ca_class_tab=0, unmapped_or_ambiguous=0,
+                  dangling_community_node=0)
+    hypotheses = []
+    for node in sorted(nodes, key=lambda n: n['id']):
+        for dep in sorted(node.get('dependencies', [])):
+            a = primary[node['spellId']]
+            target = node_map.get(dep)
+            b = primary[target['spellId']] if target else []
+            item = dict(source_node_id=node['id'], target_node_id=dep,
+                        source_spell_id=node['spellId'],
+                        target_spell_id=target['spellId'] if target else None,
+                        source_ca_ids=sorted(e['ID'] for e in a),
+                        target_ca_ids=sorted(e['ID'] for e in b),
+                        same_ca_class_tab=None)
+            if target is None:
+                status = 'dangling_community_node'
+            elif len(a) != 1 or len(b) != 1:
+                status = 'unmapped_or_ambiguous'
+            else:
+                same = (a[0]['ClassTypeID'], a[0]['TabTypeID']) == (b[0]['ClassTypeID'], b[0]['TabTypeID'])
+                item['same_ca_class_tab'] = same
+                status = 'present_runtime_edge' if (a[0]['ID'], b[0]['ID']) in pairs else 'candidate_not_runtime_edge'
+                if status == 'candidate_not_runtime_edge' and same:
+                    counts['candidates_same_ca_class_tab'] += 1
+            counts[status] += 1
+            item['status'] = status
+            hypotheses.append(item)
+    entry_ids = {e['ID'] for e in entries}
+    return dict(schema_version=1,
+                upstream_revision=dict(value=revision, status='asserted_not_verified'),
+                dependency_interpretation='community_hypotheses_not_runtime_authority',
+                sources=sorted(sources, key=lambda s: (s['role'], s['path'])),
+                summary=dict(ca_entries=len(entries), runtime_edges=len(pairs),
+                             master_ids=len(mids), master_any_rank_overlap=len(mids & ranks.keys()),
+                             master_absent_from_ca=len(mids - ranks.keys()),
+                             description_enrichment_rows=len(enrich),
+                             skill_files=len(classes), talent_files=len(classes),
+                             skill_rows=len(skills), talent_nodes=len(nodes),
+                             community_edges=counts),
+                master_absent_ids=sorted(mids - ranks.keys()),
+                numeric_crosswalk=[dict(spell_id=i, ca_rank_matches=sorted(ranks[i], key=lambda r: (r['ca_id'], r['rank']))) for i in sorted(mids)],
+                description_candidates=enrich, edge_hypotheses=hypotheses,
+                runtime_dangling_source_ids=sorted({int(a) for a in runtime} - entry_ids),
+                runtime_dangling_target_ids=sorted({b for a, b in pairs} - entry_ids))
+
+
+class PrivateArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        self.exit(2, 'comparison failed: invalid arguments\n')
+
+
+def main(argv=None):
+    parser = PrivateArgumentParser(prog='compare_ca.py', description=__doc__, allow_abbrev=False)
+    parser.add_argument('--ca-root', required=True)
+    parser.add_argument('--hub-root', required=True)
+    parser.add_argument('--upstream-revision', required=True)
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args(argv)
+    try:
+        ca_root = Path(args.ca_root).resolve(strict=True)
+        hub_root = Path(args.hub_root).resolve(strict=True)
+        output = Path(args.output)
+        resolved_output = output.resolve()
+        require(not resolved_output.is_relative_to(ca_root) and not resolved_output.is_relative_to(hub_root))
+        require(not output.exists() and not output.is_symlink())
+        report = compare(ca_root, hub_root, args.upstream_revision)
+        payload = json.dumps(report, sort_keys=True, indent=2, allow_nan=False) + '\n'
+        with output.open('x', encoding='utf-8', newline='\n') as handle:
+            handle.write(payload)
+        return 0
+    except (OSError, ValueError, TypeError, KeyError, RecursionError):
+        print('comparison failed: invalid input or output', file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/contrib/CoADataComparison/data/README.md
+++ b/contrib/CoADataComparison/data/README.md
@@ -1,0 +1,35 @@
+# Identifier comparison data
+
+This directory is the **data** half of the contribution: numeric CoA coverage
+that the engine export does not already contain as a community crosswalk.
+
+It is **not** a client dump. It contains no spell descriptions, HTML tooltips,
+icons, names, MPQs, DBCs, WDB caches, or Hub page text.
+
+## File
+
+`comparison-ids.json` was produced by `compare_ca.py` against:
+
+- this repository's `data/ca-export` at asserted revision
+  `664f2768f0695187349fc38842eae6a1588cc352`
+- a private 2026-07-31 CoA Build Hub archive (skills sourced, per that
+  archive's README, from `https://db.ascension.gg`)
+
+Re-run the tool on your own Hub archive to verify. Source SHA-256 values
+inside the JSON bind the bytes that were compared; they do not ship those
+bytes.
+
+## What you can use immediately
+
+| Field | Count | Meaning |
+|---|---:|---|
+| `master_absent_ids` | 1,571 | Hub master spell IDs that do not appear in any of the five CA rank fields. Classify before treating as missing client content. |
+| `description_candidates` | 3,600 | `{ca_id, spell_id}` rows whose CA descriptions are empty and whose Hub master record has text. Availability only; the text is not included. |
+| `non_matching_edge_hypotheses` | 193 | Community dependencies that did not map to an existing runtime edge: 142 candidate pairs, 43 unmapped/ambiguous, 8 dangling community node IDs. |
+| `runtime_dangling_target_ids` | 3 | `6451`, `7181`, `17567` — already documented in `data/ca-export/SCHEMA.md`. This comparison did not recover them. |
+
+Matching runtime edges (4,809) are omitted; they are already in
+`data/ca-export/edges.json`.
+
+These identifiers are investigation inputs. They are not an import, a
+replacement graph, or permission to copy third-party wording.

--- a/contrib/CoADataComparison/data/comparison-ids.json
+++ b/contrib/CoADataComparison/data/comparison-ids.json
@@ -1,0 +1,18927 @@
+{
+  "dependency_interpretation": "community_hypotheses_not_runtime_authority",
+  "description_candidates": [
+    {
+      "ca_id": 1374,
+      "spell_id": 804057
+    },
+    {
+      "ca_id": 1375,
+      "spell_id": 800432
+    },
+    {
+      "ca_id": 1387,
+      "spell_id": 560531
+    },
+    {
+      "ca_id": 1388,
+      "spell_id": 806978
+    },
+    {
+      "ca_id": 1389,
+      "spell_id": 520574
+    },
+    {
+      "ca_id": 1578,
+      "spell_id": 805796
+    },
+    {
+      "ca_id": 1581,
+      "spell_id": 800752
+    },
+    {
+      "ca_id": 1598,
+      "spell_id": 706671
+    },
+    {
+      "ca_id": 1662,
+      "spell_id": 521219
+    },
+    {
+      "ca_id": 1679,
+      "spell_id": 560036
+    },
+    {
+      "ca_id": 1710,
+      "spell_id": 802615
+    },
+    {
+      "ca_id": 1719,
+      "spell_id": 704421
+    },
+    {
+      "ca_id": 1721,
+      "spell_id": 803126
+    },
+    {
+      "ca_id": 1722,
+      "spell_id": 705594
+    },
+    {
+      "ca_id": 1734,
+      "spell_id": 300582
+    },
+    {
+      "ca_id": 1756,
+      "spell_id": 804094
+    },
+    {
+      "ca_id": 1770,
+      "spell_id": 806984
+    },
+    {
+      "ca_id": 1771,
+      "spell_id": 520917
+    },
+    {
+      "ca_id": 1774,
+      "spell_id": 705540
+    },
+    {
+      "ca_id": 1778,
+      "spell_id": 806993
+    },
+    {
+      "ca_id": 1779,
+      "spell_id": 806996
+    },
+    {
+      "ca_id": 1788,
+      "spell_id": 806449
+    },
+    {
+      "ca_id": 1789,
+      "spell_id": 520650
+    },
+    {
+      "ca_id": 1792,
+      "spell_id": 984147
+    },
+    {
+      "ca_id": 1802,
+      "spell_id": 572357
+    },
+    {
+      "ca_id": 1803,
+      "spell_id": 570061
+    },
+    {
+      "ca_id": 1821,
+      "spell_id": 800756
+    },
+    {
+      "ca_id": 1906,
+      "spell_id": 520753
+    },
+    {
+      "ca_id": 1930,
+      "spell_id": 705643
+    },
+    {
+      "ca_id": 1969,
+      "spell_id": 707855
+    },
+    {
+      "ca_id": 2125,
+      "spell_id": 704489
+    },
+    {
+      "ca_id": 2174,
+      "spell_id": 302923
+    },
+    {
+      "ca_id": 2253,
+      "spell_id": 806543
+    },
+    {
+      "ca_id": 2277,
+      "spell_id": 804749
+    },
+    {
+      "ca_id": 2305,
+      "spell_id": 807510
+    },
+    {
+      "ca_id": 2306,
+      "spell_id": 807509
+    },
+    {
+      "ca_id": 2309,
+      "spell_id": 707217
+    },
+    {
+      "ca_id": 2312,
+      "spell_id": 807512
+    },
+    {
+      "ca_id": 2313,
+      "spell_id": 300369
+    },
+    {
+      "ca_id": 2317,
+      "spell_id": 807749
+    },
+    {
+      "ca_id": 2386,
+      "spell_id": 680439
+    },
+    {
+      "ca_id": 2426,
+      "spell_id": 807499
+    },
+    {
+      "ca_id": 2427,
+      "spell_id": 806629
+    },
+    {
+      "ca_id": 2428,
+      "spell_id": 707115
+    },
+    {
+      "ca_id": 2429,
+      "spell_id": 524834
+    },
+    {
+      "ca_id": 2609,
+      "spell_id": 705802
+    },
+    {
+      "ca_id": 3826,
+      "spell_id": 804580
+    },
+    {
+      "ca_id": 3828,
+      "spell_id": 804561
+    },
+    {
+      "ca_id": 3829,
+      "spell_id": 807504
+    },
+    {
+      "ca_id": 3830,
+      "spell_id": 680618
+    },
+    {
+      "ca_id": 3843,
+      "spell_id": 704820
+    },
+    {
+      "ca_id": 3871,
+      "spell_id": 705085
+    },
+    {
+      "ca_id": 3924,
+      "spell_id": 301365
+    },
+    {
+      "ca_id": 3997,
+      "spell_id": 707430
+    },
+    {
+      "ca_id": 4001,
+      "spell_id": 92081
+    },
+    {
+      "ca_id": 4002,
+      "spell_id": 92082
+    },
+    {
+      "ca_id": 4003,
+      "spell_id": 92083
+    },
+    {
+      "ca_id": 4004,
+      "spell_id": 92084
+    },
+    {
+      "ca_id": 4005,
+      "spell_id": 92085
+    },
+    {
+      "ca_id": 4006,
+      "spell_id": 92086
+    },
+    {
+      "ca_id": 4007,
+      "spell_id": 92087
+    },
+    {
+      "ca_id": 4008,
+      "spell_id": 92088
+    },
+    {
+      "ca_id": 4009,
+      "spell_id": 92089
+    },
+    {
+      "ca_id": 4010,
+      "spell_id": 92091
+    },
+    {
+      "ca_id": 4011,
+      "spell_id": 92093
+    },
+    {
+      "ca_id": 4012,
+      "spell_id": 92094
+    },
+    {
+      "ca_id": 4013,
+      "spell_id": 92096
+    },
+    {
+      "ca_id": 4014,
+      "spell_id": 92097
+    },
+    {
+      "ca_id": 4015,
+      "spell_id": 92098
+    },
+    {
+      "ca_id": 4016,
+      "spell_id": 92100
+    },
+    {
+      "ca_id": 4017,
+      "spell_id": 92101
+    },
+    {
+      "ca_id": 4018,
+      "spell_id": 92104
+    },
+    {
+      "ca_id": 4019,
+      "spell_id": 92105
+    },
+    {
+      "ca_id": 4020,
+      "spell_id": 92106
+    },
+    {
+      "ca_id": 4021,
+      "spell_id": 92107
+    },
+    {
+      "ca_id": 4022,
+      "spell_id": 92108
+    },
+    {
+      "ca_id": 4023,
+      "spell_id": 92109
+    },
+    {
+      "ca_id": 4024,
+      "spell_id": 92111
+    },
+    {
+      "ca_id": 4025,
+      "spell_id": 92112
+    },
+    {
+      "ca_id": 4026,
+      "spell_id": 92113
+    },
+    {
+      "ca_id": 4027,
+      "spell_id": 92114
+    },
+    {
+      "ca_id": 4028,
+      "spell_id": 92115
+    },
+    {
+      "ca_id": 4029,
+      "spell_id": 92116
+    },
+    {
+      "ca_id": 4030,
+      "spell_id": 92117
+    },
+    {
+      "ca_id": 4031,
+      "spell_id": 92118
+    },
+    {
+      "ca_id": 4032,
+      "spell_id": 92119
+    },
+    {
+      "ca_id": 4033,
+      "spell_id": 92120
+    },
+    {
+      "ca_id": 4034,
+      "spell_id": 92121
+    },
+    {
+      "ca_id": 4035,
+      "spell_id": 92122
+    },
+    {
+      "ca_id": 4036,
+      "spell_id": 92123
+    },
+    {
+      "ca_id": 4037,
+      "spell_id": 92124
+    },
+    {
+      "ca_id": 4038,
+      "spell_id": 92126
+    },
+    {
+      "ca_id": 4039,
+      "spell_id": 300755
+    },
+    {
+      "ca_id": 4040,
+      "spell_id": 92129
+    },
+    {
+      "ca_id": 4041,
+      "spell_id": 92130
+    },
+    {
+      "ca_id": 4042,
+      "spell_id": 92131
+    },
+    {
+      "ca_id": 4043,
+      "spell_id": 92132
+    },
+    {
+      "ca_id": 4044,
+      "spell_id": 92133
+    },
+    {
+      "ca_id": 4045,
+      "spell_id": 92134
+    },
+    {
+      "ca_id": 4046,
+      "spell_id": 92135
+    },
+    {
+      "ca_id": 4047,
+      "spell_id": 92136
+    },
+    {
+      "ca_id": 4048,
+      "spell_id": 92137
+    },
+    {
+      "ca_id": 4049,
+      "spell_id": 92138
+    },
+    {
+      "ca_id": 4050,
+      "spell_id": 92140
+    },
+    {
+      "ca_id": 4051,
+      "spell_id": 92141
+    },
+    {
+      "ca_id": 4052,
+      "spell_id": 92142
+    },
+    {
+      "ca_id": 4053,
+      "spell_id": 92143
+    },
+    {
+      "ca_id": 4054,
+      "spell_id": 92144
+    },
+    {
+      "ca_id": 4055,
+      "spell_id": 92145
+    },
+    {
+      "ca_id": 4056,
+      "spell_id": 92146
+    },
+    {
+      "ca_id": 4057,
+      "spell_id": 92147
+    },
+    {
+      "ca_id": 4058,
+      "spell_id": 92148
+    },
+    {
+      "ca_id": 4059,
+      "spell_id": 92149
+    },
+    {
+      "ca_id": 4060,
+      "spell_id": 92150
+    },
+    {
+      "ca_id": 4061,
+      "spell_id": 92152
+    },
+    {
+      "ca_id": 4062,
+      "spell_id": 92153
+    },
+    {
+      "ca_id": 4063,
+      "spell_id": 92154
+    },
+    {
+      "ca_id": 4064,
+      "spell_id": 680395
+    },
+    {
+      "ca_id": 4111,
+      "spell_id": 707909
+    },
+    {
+      "ca_id": 4112,
+      "spell_id": 803700
+    },
+    {
+      "ca_id": 4123,
+      "spell_id": 712367
+    },
+    {
+      "ca_id": 4127,
+      "spell_id": 500445
+    },
+    {
+      "ca_id": 4128,
+      "spell_id": 804849
+    },
+    {
+      "ca_id": 4129,
+      "spell_id": 704652
+    },
+    {
+      "ca_id": 4132,
+      "spell_id": 705899
+    },
+    {
+      "ca_id": 4134,
+      "spell_id": 805773
+    },
+    {
+      "ca_id": 4135,
+      "spell_id": 705506
+    },
+    {
+      "ca_id": 4156,
+      "spell_id": 560701
+    },
+    {
+      "ca_id": 4161,
+      "spell_id": 807690
+    },
+    {
+      "ca_id": 4177,
+      "spell_id": 706557
+    },
+    {
+      "ca_id": 4186,
+      "spell_id": 705031
+    },
+    {
+      "ca_id": 4196,
+      "spell_id": 574147
+    },
+    {
+      "ca_id": 4201,
+      "spell_id": 301149
+    },
+    {
+      "ca_id": 4202,
+      "spell_id": 705618
+    },
+    {
+      "ca_id": 4207,
+      "spell_id": 300697
+    },
+    {
+      "ca_id": 4208,
+      "spell_id": 560156
+    },
+    {
+      "ca_id": 4217,
+      "spell_id": 520296
+    },
+    {
+      "ca_id": 4220,
+      "spell_id": 524885
+    },
+    {
+      "ca_id": 4223,
+      "spell_id": 707116
+    },
+    {
+      "ca_id": 4224,
+      "spell_id": 807297
+    },
+    {
+      "ca_id": 4225,
+      "spell_id": 704322
+    },
+    {
+      "ca_id": 4226,
+      "spell_id": 705150
+    },
+    {
+      "ca_id": 4235,
+      "spell_id": 704723
+    },
+    {
+      "ca_id": 4236,
+      "spell_id": 704724
+    },
+    {
+      "ca_id": 4237,
+      "spell_id": 807494
+    },
+    {
+      "ca_id": 4238,
+      "spell_id": 802986
+    },
+    {
+      "ca_id": 4243,
+      "spell_id": 800474
+    },
+    {
+      "ca_id": 4251,
+      "spell_id": 705541
+    },
+    {
+      "ca_id": 4253,
+      "spell_id": 706309
+    },
+    {
+      "ca_id": 4266,
+      "spell_id": 561102
+    },
+    {
+      "ca_id": 4267,
+      "spell_id": 804053
+    },
+    {
+      "ca_id": 4272,
+      "spell_id": 500286
+    },
+    {
+      "ca_id": 4287,
+      "spell_id": 301065
+    },
+    {
+      "ca_id": 4288,
+      "spell_id": 301254
+    },
+    {
+      "ca_id": 4292,
+      "spell_id": 300480
+    },
+    {
+      "ca_id": 4295,
+      "spell_id": 706940
+    },
+    {
+      "ca_id": 4297,
+      "spell_id": 801767
+    },
+    {
+      "ca_id": 4303,
+      "spell_id": 681196
+    },
+    {
+      "ca_id": 4304,
+      "spell_id": 802791
+    },
+    {
+      "ca_id": 4305,
+      "spell_id": 578120
+    },
+    {
+      "ca_id": 4306,
+      "spell_id": 807487
+    },
+    {
+      "ca_id": 4316,
+      "spell_id": 583248
+    },
+    {
+      "ca_id": 4317,
+      "spell_id": 707535
+    },
+    {
+      "ca_id": 4318,
+      "spell_id": 681328
+    },
+    {
+      "ca_id": 4319,
+      "spell_id": 680540
+    },
+    {
+      "ca_id": 4324,
+      "spell_id": 804404
+    },
+    {
+      "ca_id": 4325,
+      "spell_id": 805758
+    },
+    {
+      "ca_id": 4348,
+      "spell_id": 706431
+    },
+    {
+      "ca_id": 4354,
+      "spell_id": 805812
+    },
+    {
+      "ca_id": 4355,
+      "spell_id": 680696
+    },
+    {
+      "ca_id": 4364,
+      "spell_id": 805415
+    },
+    {
+      "ca_id": 4367,
+      "spell_id": 681173
+    },
+    {
+      "ca_id": 4384,
+      "spell_id": 800133
+    },
+    {
+      "ca_id": 4392,
+      "spell_id": 300313
+    },
+    {
+      "ca_id": 4393,
+      "spell_id": 301255
+    },
+    {
+      "ca_id": 4394,
+      "spell_id": 707382
+    },
+    {
+      "ca_id": 4410,
+      "spell_id": 300538
+    },
+    {
+      "ca_id": 4423,
+      "spell_id": 681199
+    },
+    {
+      "ca_id": 4429,
+      "spell_id": 680470
+    },
+    {
+      "ca_id": 4430,
+      "spell_id": 301066
+    },
+    {
+      "ca_id": 4431,
+      "spell_id": 300460
+    },
+    {
+      "ca_id": 4436,
+      "spell_id": 560045
+    },
+    {
+      "ca_id": 4437,
+      "spell_id": 704669
+    },
+    {
+      "ca_id": 4438,
+      "spell_id": 500981
+    },
+    {
+      "ca_id": 4475,
+      "spell_id": 705568
+    },
+    {
+      "ca_id": 4496,
+      "spell_id": 806264
+    },
+    {
+      "ca_id": 4505,
+      "spell_id": 806288
+    },
+    {
+      "ca_id": 4506,
+      "spell_id": 705843
+    },
+    {
+      "ca_id": 4520,
+      "spell_id": 706079
+    },
+    {
+      "ca_id": 4525,
+      "spell_id": 804726
+    },
+    {
+      "ca_id": 4526,
+      "spell_id": 706599
+    },
+    {
+      "ca_id": 4528,
+      "spell_id": 504252
+    },
+    {
+      "ca_id": 4532,
+      "spell_id": 705844
+    },
+    {
+      "ca_id": 4533,
+      "spell_id": 706482
+    },
+    {
+      "ca_id": 4536,
+      "spell_id": 302072
+    },
+    {
+      "ca_id": 4546,
+      "spell_id": 805301
+    },
+    {
+      "ca_id": 4547,
+      "spell_id": 704910
+    },
+    {
+      "ca_id": 4550,
+      "spell_id": 681340
+    },
+    {
+      "ca_id": 4552,
+      "spell_id": 681200
+    },
+    {
+      "ca_id": 4554,
+      "spell_id": 520628
+    },
+    {
+      "ca_id": 4572,
+      "spell_id": 503714
+    },
+    {
+      "ca_id": 4589,
+      "spell_id": 300872
+    },
+    {
+      "ca_id": 4615,
+      "spell_id": 561164
+    },
+    {
+      "ca_id": 4619,
+      "spell_id": 301207
+    },
+    {
+      "ca_id": 4620,
+      "spell_id": 500342
+    },
+    {
+      "ca_id": 4623,
+      "spell_id": 301250
+    },
+    {
+      "ca_id": 4627,
+      "spell_id": 301064
+    },
+    {
+      "ca_id": 4629,
+      "spell_id": 704661
+    },
+    {
+      "ca_id": 4631,
+      "spell_id": 707418
+    },
+    {
+      "ca_id": 4647,
+      "spell_id": 681337
+    },
+    {
+      "ca_id": 4649,
+      "spell_id": 561023
+    },
+    {
+      "ca_id": 4651,
+      "spell_id": 807654
+    },
+    {
+      "ca_id": 4654,
+      "spell_id": 301252
+    },
+    {
+      "ca_id": 4655,
+      "spell_id": 806711
+    },
+    {
+      "ca_id": 4706,
+      "spell_id": 300398
+    },
+    {
+      "ca_id": 4710,
+      "spell_id": 570713
+    },
+    {
+      "ca_id": 4715,
+      "spell_id": 705848
+    },
+    {
+      "ca_id": 4716,
+      "spell_id": 705331
+    },
+    {
+      "ca_id": 4718,
+      "spell_id": 804046
+    },
+    {
+      "ca_id": 4720,
+      "spell_id": 570236
+    },
+    {
+      "ca_id": 4733,
+      "spell_id": 707617
+    },
+    {
+      "ca_id": 4740,
+      "spell_id": 707273
+    },
+    {
+      "ca_id": 4747,
+      "spell_id": 300353
+    },
+    {
+      "ca_id": 4783,
+      "spell_id": 504339
+    },
+    {
+      "ca_id": 4794,
+      "spell_id": 681292
+    },
+    {
+      "ca_id": 4802,
+      "spell_id": 707876
+    },
+    {
+      "ca_id": 4810,
+      "spell_id": 704871
+    },
+    {
+      "ca_id": 4816,
+      "spell_id": 300943
+    },
+    {
+      "ca_id": 4836,
+      "spell_id": 300860
+    },
+    {
+      "ca_id": 4845,
+      "spell_id": 681389
+    },
+    {
+      "ca_id": 4868,
+      "spell_id": 520810
+    },
+    {
+      "ca_id": 4871,
+      "spell_id": 704107
+    },
+    {
+      "ca_id": 4883,
+      "spell_id": 707249
+    },
+    {
+      "ca_id": 4906,
+      "spell_id": 681792
+    },
+    {
+      "ca_id": 4916,
+      "spell_id": 520493
+    },
+    {
+      "ca_id": 4934,
+      "spell_id": 300753
+    },
+    {
+      "ca_id": 4936,
+      "spell_id": 704320
+    },
+    {
+      "ca_id": 4969,
+      "spell_id": 806423
+    },
+    {
+      "ca_id": 4978,
+      "spell_id": 804032
+    },
+    {
+      "ca_id": 4986,
+      "spell_id": 301239
+    },
+    {
+      "ca_id": 4987,
+      "spell_id": 707398
+    },
+    {
+      "ca_id": 5008,
+      "spell_id": 706176
+    },
+    {
+      "ca_id": 5045,
+      "spell_id": 557325
+    },
+    {
+      "ca_id": 5054,
+      "spell_id": 807459
+    },
+    {
+      "ca_id": 5055,
+      "spell_id": 572871
+    },
+    {
+      "ca_id": 5076,
+      "spell_id": 705514
+    },
+    {
+      "ca_id": 5103,
+      "spell_id": 707832
+    },
+    {
+      "ca_id": 5112,
+      "spell_id": 805546
+    },
+    {
+      "ca_id": 5113,
+      "spell_id": 706542
+    },
+    {
+      "ca_id": 5116,
+      "spell_id": 505336
+    },
+    {
+      "ca_id": 5122,
+      "spell_id": 706107
+    },
+    {
+      "ca_id": 5124,
+      "spell_id": 707389
+    },
+    {
+      "ca_id": 5151,
+      "spell_id": 704099
+    },
+    {
+      "ca_id": 5156,
+      "spell_id": 705256
+    },
+    {
+      "ca_id": 5164,
+      "spell_id": 806286
+    },
+    {
+      "ca_id": 5168,
+      "spell_id": 570067
+    },
+    {
+      "ca_id": 5172,
+      "spell_id": 800430
+    },
+    {
+      "ca_id": 5176,
+      "spell_id": 500712
+    },
+    {
+      "ca_id": 5182,
+      "spell_id": 572213
+    },
+    {
+      "ca_id": 5187,
+      "spell_id": 520485
+    },
+    {
+      "ca_id": 5192,
+      "spell_id": 570235
+    },
+    {
+      "ca_id": 5193,
+      "spell_id": 561037
+    },
+    {
+      "ca_id": 5195,
+      "spell_id": 705827
+    },
+    {
+      "ca_id": 5203,
+      "spell_id": 706572
+    },
+    {
+      "ca_id": 5210,
+      "spell_id": 704360
+    },
+    {
+      "ca_id": 5212,
+      "spell_id": 801389
+    },
+    {
+      "ca_id": 5215,
+      "spell_id": 503930
+    },
+    {
+      "ca_id": 5227,
+      "spell_id": 804571
+    },
+    {
+      "ca_id": 5235,
+      "spell_id": 707329
+    },
+    {
+      "ca_id": 5253,
+      "spell_id": 802714
+    },
+    {
+      "ca_id": 5254,
+      "spell_id": 563123
+    },
+    {
+      "ca_id": 5290,
+      "spell_id": 707283
+    },
+    {
+      "ca_id": 5291,
+      "spell_id": 680768
+    },
+    {
+      "ca_id": 5302,
+      "spell_id": 681320
+    },
+    {
+      "ca_id": 5303,
+      "spell_id": 705942
+    },
+    {
+      "ca_id": 5311,
+      "spell_id": 705039
+    },
+    {
+      "ca_id": 5312,
+      "spell_id": 560857
+    },
+    {
+      "ca_id": 5314,
+      "spell_id": 504316
+    },
+    {
+      "ca_id": 5318,
+      "spell_id": 705176
+    },
+    {
+      "ca_id": 5327,
+      "spell_id": 805835
+    },
+    {
+      "ca_id": 5329,
+      "spell_id": 560518
+    },
+    {
+      "ca_id": 5331,
+      "spell_id": 572545
+    },
+    {
+      "ca_id": 5332,
+      "spell_id": 560545
+    },
+    {
+      "ca_id": 5333,
+      "spell_id": 704511
+    },
+    {
+      "ca_id": 5349,
+      "spell_id": 300545
+    },
+    {
+      "ca_id": 5351,
+      "spell_id": 520812
+    },
+    {
+      "ca_id": 5354,
+      "spell_id": 707371
+    },
+    {
+      "ca_id": 5367,
+      "spell_id": 707557
+    },
+    {
+      "ca_id": 5373,
+      "spell_id": 800131
+    },
+    {
+      "ca_id": 5384,
+      "spell_id": 560257
+    },
+    {
+      "ca_id": 5392,
+      "spell_id": 706758
+    },
+    {
+      "ca_id": 5393,
+      "spell_id": 560219
+    },
+    {
+      "ca_id": 5430,
+      "spell_id": 803108
+    },
+    {
+      "ca_id": 5431,
+      "spell_id": 705098
+    },
+    {
+      "ca_id": 5433,
+      "spell_id": 704515
+    },
+    {
+      "ca_id": 5438,
+      "spell_id": 706449
+    },
+    {
+      "ca_id": 5444,
+      "spell_id": 807292
+    },
+    {
+      "ca_id": 5451,
+      "spell_id": 705592
+    },
+    {
+      "ca_id": 5453,
+      "spell_id": 807247
+    },
+    {
+      "ca_id": 5464,
+      "spell_id": 805185
+    },
+    {
+      "ca_id": 5470,
+      "spell_id": 560434
+    },
+    {
+      "ca_id": 5475,
+      "spell_id": 801869
+    },
+    {
+      "ca_id": 5486,
+      "spell_id": 583245
+    },
+    {
+      "ca_id": 5491,
+      "spell_id": 707395
+    },
+    {
+      "ca_id": 5495,
+      "spell_id": 572340
+    },
+    {
+      "ca_id": 5503,
+      "spell_id": 520809
+    },
+    {
+      "ca_id": 5532,
+      "spell_id": 560140
+    },
+    {
+      "ca_id": 5544,
+      "spell_id": 802793
+    },
+    {
+      "ca_id": 5562,
+      "spell_id": 805708
+    },
+    {
+      "ca_id": 5563,
+      "spell_id": 560073
+    },
+    {
+      "ca_id": 5571,
+      "spell_id": 503960
+    },
+    {
+      "ca_id": 5575,
+      "spell_id": 504355
+    },
+    {
+      "ca_id": 5600,
+      "spell_id": 800845
+    },
+    {
+      "ca_id": 5605,
+      "spell_id": 560851
+    },
+    {
+      "ca_id": 5608,
+      "spell_id": 560880
+    },
+    {
+      "ca_id": 5648,
+      "spell_id": 520145
+    },
+    {
+      "ca_id": 5676,
+      "spell_id": 705846
+    },
+    {
+      "ca_id": 5678,
+      "spell_id": 705500
+    },
+    {
+      "ca_id": 5685,
+      "spell_id": 681376
+    },
+    {
+      "ca_id": 5713,
+      "spell_id": 805423
+    },
+    {
+      "ca_id": 5722,
+      "spell_id": 301366
+    },
+    {
+      "ca_id": 5738,
+      "spell_id": 705639
+    },
+    {
+      "ca_id": 5744,
+      "spell_id": 804414
+    },
+    {
+      "ca_id": 5753,
+      "spell_id": 300237
+    },
+    {
+      "ca_id": 5762,
+      "spell_id": 707707
+    },
+    {
+      "ca_id": 5766,
+      "spell_id": 638403
+    },
+    {
+      "ca_id": 5767,
+      "spell_id": 705410
+    },
+    {
+      "ca_id": 5781,
+      "spell_id": 704713
+    },
+    {
+      "ca_id": 5794,
+      "spell_id": 500984
+    },
+    {
+      "ca_id": 5825,
+      "spell_id": 505201
+    },
+    {
+      "ca_id": 5854,
+      "spell_id": 704800
+    },
+    {
+      "ca_id": 5861,
+      "spell_id": 806312
+    },
+    {
+      "ca_id": 5892,
+      "spell_id": 561138
+    },
+    {
+      "ca_id": 5907,
+      "spell_id": 704621
+    },
+    {
+      "ca_id": 5908,
+      "spell_id": 520804
+    },
+    {
+      "ca_id": 5934,
+      "spell_id": 706434
+    },
+    {
+      "ca_id": 5961,
+      "spell_id": 504525
+    },
+    {
+      "ca_id": 5965,
+      "spell_id": 805306
+    },
+    {
+      "ca_id": 5966,
+      "spell_id": 807635
+    },
+    {
+      "ca_id": 5970,
+      "spell_id": 705789
+    },
+    {
+      "ca_id": 5972,
+      "spell_id": 560742
+    },
+    {
+      "ca_id": 5974,
+      "spell_id": 707265
+    },
+    {
+      "ca_id": 5978,
+      "spell_id": 807498
+    },
+    {
+      "ca_id": 5979,
+      "spell_id": 560735
+    },
+    {
+      "ca_id": 5980,
+      "spell_id": 807531
+    },
+    {
+      "ca_id": 5982,
+      "spell_id": 805305
+    },
+    {
+      "ca_id": 5985,
+      "spell_id": 805314
+    },
+    {
+      "ca_id": 5989,
+      "spell_id": 506818
+    },
+    {
+      "ca_id": 5990,
+      "spell_id": 707237
+    },
+    {
+      "ca_id": 5991,
+      "spell_id": 707277
+    },
+    {
+      "ca_id": 5995,
+      "spell_id": 505327
+    },
+    {
+      "ca_id": 5996,
+      "spell_id": 806762
+    },
+    {
+      "ca_id": 5997,
+      "spell_id": 520445
+    },
+    {
+      "ca_id": 5998,
+      "spell_id": 704111
+    },
+    {
+      "ca_id": 5999,
+      "spell_id": 707104
+    },
+    {
+      "ca_id": 6001,
+      "spell_id": 705781
+    },
+    {
+      "ca_id": 6007,
+      "spell_id": 707168
+    },
+    {
+      "ca_id": 6009,
+      "spell_id": 500472
+    },
+    {
+      "ca_id": 6010,
+      "spell_id": 706488
+    },
+    {
+      "ca_id": 6011,
+      "spell_id": 300662
+    },
+    {
+      "ca_id": 6013,
+      "spell_id": 301175
+    },
+    {
+      "ca_id": 6014,
+      "spell_id": 560544
+    },
+    {
+      "ca_id": 6015,
+      "spell_id": 705850
+    },
+    {
+      "ca_id": 6016,
+      "spell_id": 705851
+    },
+    {
+      "ca_id": 6020,
+      "spell_id": 705859
+    },
+    {
+      "ca_id": 6021,
+      "spell_id": 801664
+    },
+    {
+      "ca_id": 6022,
+      "spell_id": 707212
+    },
+    {
+      "ca_id": 6023,
+      "spell_id": 300660
+    },
+    {
+      "ca_id": 6026,
+      "spell_id": 801690
+    },
+    {
+      "ca_id": 6027,
+      "spell_id": 802487
+    },
+    {
+      "ca_id": 6030,
+      "spell_id": 503742
+    },
+    {
+      "ca_id": 6031,
+      "spell_id": 500952
+    },
+    {
+      "ca_id": 6035,
+      "spell_id": 705939
+    },
+    {
+      "ca_id": 6042,
+      "spell_id": 504465
+    },
+    {
+      "ca_id": 6044,
+      "spell_id": 705871
+    },
+    {
+      "ca_id": 6045,
+      "spell_id": 705917
+    },
+    {
+      "ca_id": 6046,
+      "spell_id": 707505
+    },
+    {
+      "ca_id": 6047,
+      "spell_id": 705903
+    },
+    {
+      "ca_id": 6048,
+      "spell_id": 712396
+    },
+    {
+      "ca_id": 6049,
+      "spell_id": 705906
+    },
+    {
+      "ca_id": 6050,
+      "spell_id": 705909
+    },
+    {
+      "ca_id": 6051,
+      "spell_id": 804226
+    },
+    {
+      "ca_id": 6052,
+      "spell_id": 705907
+    },
+    {
+      "ca_id": 6053,
+      "spell_id": 705901
+    },
+    {
+      "ca_id": 6054,
+      "spell_id": 705911
+    },
+    {
+      "ca_id": 6055,
+      "spell_id": 704497
+    },
+    {
+      "ca_id": 6057,
+      "spell_id": 705916
+    },
+    {
+      "ca_id": 6058,
+      "spell_id": 705922
+    },
+    {
+      "ca_id": 6059,
+      "spell_id": 504462
+    },
+    {
+      "ca_id": 6062,
+      "spell_id": 705840
+    },
+    {
+      "ca_id": 6063,
+      "spell_id": 706577
+    },
+    {
+      "ca_id": 6069,
+      "spell_id": 706543
+    },
+    {
+      "ca_id": 6072,
+      "spell_id": 503727
+    },
+    {
+      "ca_id": 6073,
+      "spell_id": 525377
+    },
+    {
+      "ca_id": 6074,
+      "spell_id": 680882
+    },
+    {
+      "ca_id": 6076,
+      "spell_id": 705948
+    },
+    {
+      "ca_id": 6078,
+      "spell_id": 804975
+    },
+    {
+      "ca_id": 6079,
+      "spell_id": 806154
+    },
+    {
+      "ca_id": 6080,
+      "spell_id": 706026
+    },
+    {
+      "ca_id": 6082,
+      "spell_id": 300664
+    },
+    {
+      "ca_id": 6086,
+      "spell_id": 805775
+    },
+    {
+      "ca_id": 6089,
+      "spell_id": 705998
+    },
+    {
+      "ca_id": 6090,
+      "spell_id": 503856
+    },
+    {
+      "ca_id": 6095,
+      "spell_id": 681052
+    },
+    {
+      "ca_id": 6096,
+      "spell_id": 560282
+    },
+    {
+      "ca_id": 6097,
+      "spell_id": 503850
+    },
+    {
+      "ca_id": 6098,
+      "spell_id": 800894
+    },
+    {
+      "ca_id": 6099,
+      "spell_id": 300974
+    },
+    {
+      "ca_id": 6101,
+      "spell_id": 706002
+    },
+    {
+      "ca_id": 6102,
+      "spell_id": 503812
+    },
+    {
+      "ca_id": 6103,
+      "spell_id": 504402
+    },
+    {
+      "ca_id": 6104,
+      "spell_id": 804993
+    },
+    {
+      "ca_id": 6106,
+      "spell_id": 705980
+    },
+    {
+      "ca_id": 6107,
+      "spell_id": 706006
+    },
+    {
+      "ca_id": 6108,
+      "spell_id": 705959
+    },
+    {
+      "ca_id": 6110,
+      "spell_id": 705982
+    },
+    {
+      "ca_id": 6112,
+      "spell_id": 805102
+    },
+    {
+      "ca_id": 6113,
+      "spell_id": 704264
+    },
+    {
+      "ca_id": 6115,
+      "spell_id": 705975
+    },
+    {
+      "ca_id": 6116,
+      "spell_id": 805778
+    },
+    {
+      "ca_id": 6117,
+      "spell_id": 705962
+    },
+    {
+      "ca_id": 6118,
+      "spell_id": 504799
+    },
+    {
+      "ca_id": 6119,
+      "spell_id": 560247
+    },
+    {
+      "ca_id": 6120,
+      "spell_id": 705969
+    },
+    {
+      "ca_id": 6122,
+      "spell_id": 706955
+    },
+    {
+      "ca_id": 6125,
+      "spell_id": 705967
+    },
+    {
+      "ca_id": 6128,
+      "spell_id": 707726
+    },
+    {
+      "ca_id": 6130,
+      "spell_id": 706007
+    },
+    {
+      "ca_id": 6131,
+      "spell_id": 804984
+    },
+    {
+      "ca_id": 6132,
+      "spell_id": 681048
+    },
+    {
+      "ca_id": 6133,
+      "spell_id": 680767
+    },
+    {
+      "ca_id": 6137,
+      "spell_id": 804987
+    },
+    {
+      "ca_id": 6138,
+      "spell_id": 805900
+    },
+    {
+      "ca_id": 6139,
+      "spell_id": 706018
+    },
+    {
+      "ca_id": 6141,
+      "spell_id": 503918
+    },
+    {
+      "ca_id": 6142,
+      "spell_id": 706956
+    },
+    {
+      "ca_id": 6143,
+      "spell_id": 503919
+    },
+    {
+      "ca_id": 6144,
+      "spell_id": 706270
+    },
+    {
+      "ca_id": 6146,
+      "spell_id": 630932
+    },
+    {
+      "ca_id": 6147,
+      "spell_id": 680871
+    },
+    {
+      "ca_id": 6148,
+      "spell_id": 807601
+    },
+    {
+      "ca_id": 6149,
+      "spell_id": 500294
+    },
+    {
+      "ca_id": 6151,
+      "spell_id": 806559
+    },
+    {
+      "ca_id": 6155,
+      "spell_id": 680451
+    },
+    {
+      "ca_id": 6156,
+      "spell_id": 503825
+    },
+    {
+      "ca_id": 6158,
+      "spell_id": 560528
+    },
+    {
+      "ca_id": 6159,
+      "spell_id": 706059
+    },
+    {
+      "ca_id": 6161,
+      "spell_id": 805844
+    },
+    {
+      "ca_id": 6162,
+      "spell_id": 806300
+    },
+    {
+      "ca_id": 6164,
+      "spell_id": 707553
+    },
+    {
+      "ca_id": 6170,
+      "spell_id": 560130
+    },
+    {
+      "ca_id": 6171,
+      "spell_id": 807588
+    },
+    {
+      "ca_id": 6172,
+      "spell_id": 806204
+    },
+    {
+      "ca_id": 6173,
+      "spell_id": 680373
+    },
+    {
+      "ca_id": 6174,
+      "spell_id": 806203
+    },
+    {
+      "ca_id": 6175,
+      "spell_id": 503836
+    },
+    {
+      "ca_id": 6178,
+      "spell_id": 706130
+    },
+    {
+      "ca_id": 6182,
+      "spell_id": 706083
+    },
+    {
+      "ca_id": 6183,
+      "spell_id": 706779
+    },
+    {
+      "ca_id": 6184,
+      "spell_id": 570149
+    },
+    {
+      "ca_id": 6187,
+      "spell_id": 574310
+    },
+    {
+      "ca_id": 6190,
+      "spell_id": 520042
+    },
+    {
+      "ca_id": 6192,
+      "spell_id": 706098
+    },
+    {
+      "ca_id": 6194,
+      "spell_id": 706099
+    },
+    {
+      "ca_id": 6195,
+      "spell_id": 706100
+    },
+    {
+      "ca_id": 6196,
+      "spell_id": 706131
+    },
+    {
+      "ca_id": 6199,
+      "spell_id": 520780
+    },
+    {
+      "ca_id": 6200,
+      "spell_id": 806337
+    },
+    {
+      "ca_id": 6201,
+      "spell_id": 524677
+    },
+    {
+      "ca_id": 6202,
+      "spell_id": 500764
+    },
+    {
+      "ca_id": 6205,
+      "spell_id": 500940
+    },
+    {
+      "ca_id": 6206,
+      "spell_id": 300691
+    },
+    {
+      "ca_id": 6211,
+      "spell_id": 520464
+    },
+    {
+      "ca_id": 6213,
+      "spell_id": 706055
+    },
+    {
+      "ca_id": 6214,
+      "spell_id": 560948
+    },
+    {
+      "ca_id": 6215,
+      "spell_id": 680845
+    },
+    {
+      "ca_id": 6221,
+      "spell_id": 520855
+    },
+    {
+      "ca_id": 6223,
+      "spell_id": 706063
+    },
+    {
+      "ca_id": 6226,
+      "spell_id": 520164
+    },
+    {
+      "ca_id": 6228,
+      "spell_id": 804491
+    },
+    {
+      "ca_id": 6230,
+      "spell_id": 706137
+    },
+    {
+      "ca_id": 6234,
+      "spell_id": 300738
+    },
+    {
+      "ca_id": 6235,
+      "spell_id": 806536
+    },
+    {
+      "ca_id": 6236,
+      "spell_id": 504220
+    },
+    {
+      "ca_id": 6238,
+      "spell_id": 300733
+    },
+    {
+      "ca_id": 6240,
+      "spell_id": 300867
+    },
+    {
+      "ca_id": 6242,
+      "spell_id": 300731
+    },
+    {
+      "ca_id": 6243,
+      "spell_id": 504214
+    },
+    {
+      "ca_id": 6246,
+      "spell_id": 804705
+    },
+    {
+      "ca_id": 6251,
+      "spell_id": 300690
+    },
+    {
+      "ca_id": 6257,
+      "spell_id": 706174
+    },
+    {
+      "ca_id": 6260,
+      "spell_id": 706165
+    },
+    {
+      "ca_id": 6261,
+      "spell_id": 706153
+    },
+    {
+      "ca_id": 6262,
+      "spell_id": 504219
+    },
+    {
+      "ca_id": 6267,
+      "spell_id": 500615
+    },
+    {
+      "ca_id": 6269,
+      "spell_id": 504229
+    },
+    {
+      "ca_id": 6270,
+      "spell_id": 801231
+    },
+    {
+      "ca_id": 6272,
+      "spell_id": 805114
+    },
+    {
+      "ca_id": 6274,
+      "spell_id": 500721
+    },
+    {
+      "ca_id": 6275,
+      "spell_id": 582307
+    },
+    {
+      "ca_id": 6276,
+      "spell_id": 704878
+    },
+    {
+      "ca_id": 6277,
+      "spell_id": 582591
+    },
+    {
+      "ca_id": 6278,
+      "spell_id": 704885
+    },
+    {
+      "ca_id": 6279,
+      "spell_id": 804633
+    },
+    {
+      "ca_id": 6280,
+      "spell_id": 573028
+    },
+    {
+      "ca_id": 6281,
+      "spell_id": 300265
+    },
+    {
+      "ca_id": 6283,
+      "spell_id": 704895
+    },
+    {
+      "ca_id": 6289,
+      "spell_id": 680446
+    },
+    {
+      "ca_id": 6290,
+      "spell_id": 706948
+    },
+    {
+      "ca_id": 6295,
+      "spell_id": 300960
+    },
+    {
+      "ca_id": 6298,
+      "spell_id": 706203
+    },
+    {
+      "ca_id": 6302,
+      "spell_id": 681059
+    },
+    {
+      "ca_id": 6303,
+      "spell_id": 560135
+    },
+    {
+      "ca_id": 6305,
+      "spell_id": 706201
+    },
+    {
+      "ca_id": 6310,
+      "spell_id": 300284
+    },
+    {
+      "ca_id": 6312,
+      "spell_id": 706915
+    },
+    {
+      "ca_id": 6313,
+      "spell_id": 300258
+    },
+    {
+      "ca_id": 6314,
+      "spell_id": 704776
+    },
+    {
+      "ca_id": 6315,
+      "spell_id": 800508
+    },
+    {
+      "ca_id": 6316,
+      "spell_id": 706230
+    },
+    {
+      "ca_id": 6317,
+      "spell_id": 704790
+    },
+    {
+      "ca_id": 6322,
+      "spell_id": 300336
+    },
+    {
+      "ca_id": 6323,
+      "spell_id": 802167
+    },
+    {
+      "ca_id": 6325,
+      "spell_id": 705497
+    },
+    {
+      "ca_id": 6326,
+      "spell_id": 681445
+    },
+    {
+      "ca_id": 6327,
+      "spell_id": 300302
+    },
+    {
+      "ca_id": 6328,
+      "spell_id": 804604
+    },
+    {
+      "ca_id": 6331,
+      "spell_id": 706035
+    },
+    {
+      "ca_id": 6332,
+      "spell_id": 300251
+    },
+    {
+      "ca_id": 6333,
+      "spell_id": 705803
+    },
+    {
+      "ca_id": 6334,
+      "spell_id": 705455
+    },
+    {
+      "ca_id": 6335,
+      "spell_id": 572885
+    },
+    {
+      "ca_id": 6336,
+      "spell_id": 560534
+    },
+    {
+      "ca_id": 6337,
+      "spell_id": 704211
+    },
+    {
+      "ca_id": 6338,
+      "spell_id": 560576
+    },
+    {
+      "ca_id": 6339,
+      "spell_id": 685321
+    },
+    {
+      "ca_id": 6340,
+      "spell_id": 802180
+    },
+    {
+      "ca_id": 6341,
+      "spell_id": 503852
+    },
+    {
+      "ca_id": 6342,
+      "spell_id": 300678
+    },
+    {
+      "ca_id": 6346,
+      "spell_id": 300897
+    },
+    {
+      "ca_id": 6347,
+      "spell_id": 560339
+    },
+    {
+      "ca_id": 6348,
+      "spell_id": 706281
+    },
+    {
+      "ca_id": 6350,
+      "spell_id": 300499
+    },
+    {
+      "ca_id": 6351,
+      "spell_id": 520032
+    },
+    {
+      "ca_id": 6352,
+      "spell_id": 520017
+    },
+    {
+      "ca_id": 6354,
+      "spell_id": 801455
+    },
+    {
+      "ca_id": 6355,
+      "spell_id": 300501
+    },
+    {
+      "ca_id": 6356,
+      "spell_id": 300522
+    },
+    {
+      "ca_id": 6358,
+      "spell_id": 560833
+    },
+    {
+      "ca_id": 6360,
+      "spell_id": 707614
+    },
+    {
+      "ca_id": 6362,
+      "spell_id": 504148
+    },
+    {
+      "ca_id": 6363,
+      "spell_id": 300927
+    },
+    {
+      "ca_id": 6364,
+      "spell_id": 504385
+    },
+    {
+      "ca_id": 6365,
+      "spell_id": 300688
+    },
+    {
+      "ca_id": 6367,
+      "spell_id": 537212
+    },
+    {
+      "ca_id": 6374,
+      "spell_id": 801549
+    },
+    {
+      "ca_id": 6375,
+      "spell_id": 560649
+    },
+    {
+      "ca_id": 6376,
+      "spell_id": 805421
+    },
+    {
+      "ca_id": 6378,
+      "spell_id": 705605
+    },
+    {
+      "ca_id": 6379,
+      "spell_id": 500101
+    },
+    {
+      "ca_id": 6381,
+      "spell_id": 706368
+    },
+    {
+      "ca_id": 6382,
+      "spell_id": 560301
+    },
+    {
+      "ca_id": 6385,
+      "spell_id": 707262
+    },
+    {
+      "ca_id": 6386,
+      "spell_id": 520811
+    },
+    {
+      "ca_id": 6388,
+      "spell_id": 681007
+    },
+    {
+      "ca_id": 6389,
+      "spell_id": 500250
+    },
+    {
+      "ca_id": 6390,
+      "spell_id": 707908
+    },
+    {
+      "ca_id": 6391,
+      "spell_id": 706563
+    },
+    {
+      "ca_id": 6392,
+      "spell_id": 805677
+    },
+    {
+      "ca_id": 6393,
+      "spell_id": 704991
+    },
+    {
+      "ca_id": 6394,
+      "spell_id": 704185
+    },
+    {
+      "ca_id": 6398,
+      "spell_id": 806738
+    },
+    {
+      "ca_id": 6399,
+      "spell_id": 706574
+    },
+    {
+      "ca_id": 6401,
+      "spell_id": 572546
+    },
+    {
+      "ca_id": 6405,
+      "spell_id": 560250
+    },
+    {
+      "ca_id": 6408,
+      "spell_id": 704634
+    },
+    {
+      "ca_id": 6410,
+      "spell_id": 501132
+    },
+    {
+      "ca_id": 6411,
+      "spell_id": 705477
+    },
+    {
+      "ca_id": 6413,
+      "spell_id": 802278
+    },
+    {
+      "ca_id": 6415,
+      "spell_id": 680529
+    },
+    {
+      "ca_id": 6417,
+      "spell_id": 300795
+    },
+    {
+      "ca_id": 6418,
+      "spell_id": 705715
+    },
+    {
+      "ca_id": 6423,
+      "spell_id": 520251
+    },
+    {
+      "ca_id": 6425,
+      "spell_id": 300834
+    },
+    {
+      "ca_id": 6426,
+      "spell_id": 804038
+    },
+    {
+      "ca_id": 6427,
+      "spell_id": 706625
+    },
+    {
+      "ca_id": 6428,
+      "spell_id": 704525
+    },
+    {
+      "ca_id": 6429,
+      "spell_id": 300541
+    },
+    {
+      "ca_id": 6430,
+      "spell_id": 704516
+    },
+    {
+      "ca_id": 6431,
+      "spell_id": 504503
+    },
+    {
+      "ca_id": 6432,
+      "spell_id": 705361
+    },
+    {
+      "ca_id": 6433,
+      "spell_id": 705329
+    },
+    {
+      "ca_id": 6434,
+      "spell_id": 504139
+    },
+    {
+      "ca_id": 6435,
+      "spell_id": 707543
+    },
+    {
+      "ca_id": 6436,
+      "spell_id": 705067
+    },
+    {
+      "ca_id": 6437,
+      "spell_id": 520586
+    },
+    {
+      "ca_id": 6445,
+      "spell_id": 706344
+    },
+    {
+      "ca_id": 6454,
+      "spell_id": 704423
+    },
+    {
+      "ca_id": 6455,
+      "spell_id": 705368
+    },
+    {
+      "ca_id": 6456,
+      "spell_id": 706637
+    },
+    {
+      "ca_id": 6457,
+      "spell_id": 705496
+    },
+    {
+      "ca_id": 6458,
+      "spell_id": 300241
+    },
+    {
+      "ca_id": 6459,
+      "spell_id": 300234
+    },
+    {
+      "ca_id": 6461,
+      "spell_id": 804300
+    },
+    {
+      "ca_id": 6462,
+      "spell_id": 706353
+    },
+    {
+      "ca_id": 6463,
+      "spell_id": 704623
+    },
+    {
+      "ca_id": 6466,
+      "spell_id": 504846
+    },
+    {
+      "ca_id": 6467,
+      "spell_id": 706661
+    },
+    {
+      "ca_id": 6468,
+      "spell_id": 806397
+    },
+    {
+      "ca_id": 6469,
+      "spell_id": 300961
+    },
+    {
+      "ca_id": 6470,
+      "spell_id": 706458
+    },
+    {
+      "ca_id": 6472,
+      "spell_id": 705575
+    },
+    {
+      "ca_id": 6473,
+      "spell_id": 560039
+    },
+    {
+      "ca_id": 6474,
+      "spell_id": 705570
+    },
+    {
+      "ca_id": 6475,
+      "spell_id": 560037
+    },
+    {
+      "ca_id": 6476,
+      "spell_id": 707157
+    },
+    {
+      "ca_id": 6477,
+      "spell_id": 800757
+    },
+    {
+      "ca_id": 6478,
+      "spell_id": 707460
+    },
+    {
+      "ca_id": 6481,
+      "spell_id": 804061
+    },
+    {
+      "ca_id": 6482,
+      "spell_id": 520755
+    },
+    {
+      "ca_id": 6483,
+      "spell_id": 706523
+    },
+    {
+      "ca_id": 6485,
+      "spell_id": 705586
+    },
+    {
+      "ca_id": 6486,
+      "spell_id": 802669
+    },
+    {
+      "ca_id": 6487,
+      "spell_id": 712308
+    },
+    {
+      "ca_id": 6488,
+      "spell_id": 803291
+    },
+    {
+      "ca_id": 6491,
+      "spell_id": 705786
+    },
+    {
+      "ca_id": 6493,
+      "spell_id": 705619
+    },
+    {
+      "ca_id": 6495,
+      "spell_id": 707423
+    },
+    {
+      "ca_id": 6498,
+      "spell_id": 705856
+    },
+    {
+      "ca_id": 6499,
+      "spell_id": 802068
+    },
+    {
+      "ca_id": 6500,
+      "spell_id": 707482
+    },
+    {
+      "ca_id": 6501,
+      "spell_id": 503915
+    },
+    {
+      "ca_id": 6504,
+      "spell_id": 681003
+    },
+    {
+      "ca_id": 6505,
+      "spell_id": 707240
+    },
+    {
+      "ca_id": 6509,
+      "spell_id": 504223
+    },
+    {
+      "ca_id": 6510,
+      "spell_id": 704654
+    },
+    {
+      "ca_id": 6511,
+      "spell_id": 705234
+    },
+    {
+      "ca_id": 6512,
+      "spell_id": 704361
+    },
+    {
+      "ca_id": 6513,
+      "spell_id": 803903
+    },
+    {
+      "ca_id": 6514,
+      "spell_id": 704487
+    },
+    {
+      "ca_id": 6518,
+      "spell_id": 681449
+    },
+    {
+      "ca_id": 6519,
+      "spell_id": 704999
+    },
+    {
+      "ca_id": 6521,
+      "spell_id": 504046
+    },
+    {
+      "ca_id": 6522,
+      "spell_id": 680971
+    },
+    {
+      "ca_id": 6524,
+      "spell_id": 520244
+    },
+    {
+      "ca_id": 6525,
+      "spell_id": 806469
+    },
+    {
+      "ca_id": 6526,
+      "spell_id": 800207
+    },
+    {
+      "ca_id": 6529,
+      "spell_id": 681450
+    },
+    {
+      "ca_id": 6530,
+      "spell_id": 680200
+    },
+    {
+      "ca_id": 6531,
+      "spell_id": 707403
+    },
+    {
+      "ca_id": 6535,
+      "spell_id": 704942
+    },
+    {
+      "ca_id": 6539,
+      "spell_id": 807507
+    },
+    {
+      "ca_id": 6542,
+      "spell_id": 300275
+    },
+    {
+      "ca_id": 6543,
+      "spell_id": 582836
+    },
+    {
+      "ca_id": 6545,
+      "spell_id": 680609
+    },
+    {
+      "ca_id": 6547,
+      "spell_id": 706807
+    },
+    {
+      "ca_id": 6548,
+      "spell_id": 300315
+    },
+    {
+      "ca_id": 6551,
+      "spell_id": 705825
+    },
+    {
+      "ca_id": 6552,
+      "spell_id": 504361
+    },
+    {
+      "ca_id": 6553,
+      "spell_id": 504347
+    },
+    {
+      "ca_id": 6554,
+      "spell_id": 524818
+    },
+    {
+      "ca_id": 6555,
+      "spell_id": 300945
+    },
+    {
+      "ca_id": 6556,
+      "spell_id": 705657
+    },
+    {
+      "ca_id": 6557,
+      "spell_id": 706179
+    },
+    {
+      "ca_id": 6558,
+      "spell_id": 560861
+    },
+    {
+      "ca_id": 6559,
+      "spell_id": 300309
+    },
+    {
+      "ca_id": 6563,
+      "spell_id": 707767
+    },
+    {
+      "ca_id": 6564,
+      "spell_id": 704579
+    },
+    {
+      "ca_id": 6565,
+      "spell_id": 805816
+    },
+    {
+      "ca_id": 6566,
+      "spell_id": 300513
+    },
+    {
+      "ca_id": 6567,
+      "spell_id": 500011
+    },
+    {
+      "ca_id": 6569,
+      "spell_id": 504248
+    },
+    {
+      "ca_id": 6574,
+      "spell_id": 706122
+    },
+    {
+      "ca_id": 6575,
+      "spell_id": 560129
+    },
+    {
+      "ca_id": 6576,
+      "spell_id": 500116
+    },
+    {
+      "ca_id": 6578,
+      "spell_id": 560182
+    },
+    {
+      "ca_id": 6586,
+      "spell_id": 680452
+    },
+    {
+      "ca_id": 6587,
+      "spell_id": 706160
+    },
+    {
+      "ca_id": 6588,
+      "spell_id": 680862
+    },
+    {
+      "ca_id": 6590,
+      "spell_id": 560158
+    },
+    {
+      "ca_id": 6593,
+      "spell_id": 560481
+    },
+    {
+      "ca_id": 6594,
+      "spell_id": 805336
+    },
+    {
+      "ca_id": 6600,
+      "spell_id": 706162
+    },
+    {
+      "ca_id": 6605,
+      "spell_id": 804989
+    },
+    {
+      "ca_id": 6607,
+      "spell_id": 706009
+    },
+    {
+      "ca_id": 6608,
+      "spell_id": 705240
+    },
+    {
+      "ca_id": 6610,
+      "spell_id": 681327
+    },
+    {
+      "ca_id": 6613,
+      "spell_id": 805533
+    },
+    {
+      "ca_id": 6614,
+      "spell_id": 802277
+    },
+    {
+      "ca_id": 6615,
+      "spell_id": 705512
+    },
+    {
+      "ca_id": 6618,
+      "spell_id": 560207
+    },
+    {
+      "ca_id": 6619,
+      "spell_id": 300391
+    },
+    {
+      "ca_id": 6620,
+      "spell_id": 706569
+    },
+    {
+      "ca_id": 6622,
+      "spell_id": 802269
+    },
+    {
+      "ca_id": 6625,
+      "spell_id": 560226
+    },
+    {
+      "ca_id": 6627,
+      "spell_id": 560072
+    },
+    {
+      "ca_id": 6629,
+      "spell_id": 561278
+    },
+    {
+      "ca_id": 6630,
+      "spell_id": 560254
+    },
+    {
+      "ca_id": 6633,
+      "spell_id": 680680
+    },
+    {
+      "ca_id": 6634,
+      "spell_id": 680745
+    },
+    {
+      "ca_id": 6641,
+      "spell_id": 802203
+    },
+    {
+      "ca_id": 6643,
+      "spell_id": 803997
+    },
+    {
+      "ca_id": 6644,
+      "spell_id": 704503
+    },
+    {
+      "ca_id": 6645,
+      "spell_id": 561069
+    },
+    {
+      "ca_id": 6646,
+      "spell_id": 560194
+    },
+    {
+      "ca_id": 6651,
+      "spell_id": 706216
+    },
+    {
+      "ca_id": 6652,
+      "spell_id": 706134
+    },
+    {
+      "ca_id": 6653,
+      "spell_id": 300355
+    },
+    {
+      "ca_id": 6654,
+      "spell_id": 300744
+    },
+    {
+      "ca_id": 6656,
+      "spell_id": 504103
+    },
+    {
+      "ca_id": 6659,
+      "spell_id": 801226
+    },
+    {
+      "ca_id": 6660,
+      "spell_id": 704774
+    },
+    {
+      "ca_id": 6661,
+      "spell_id": 704848
+    },
+    {
+      "ca_id": 6662,
+      "spell_id": 807466
+    },
+    {
+      "ca_id": 6664,
+      "spell_id": 560321
+    },
+    {
+      "ca_id": 6665,
+      "spell_id": 561191
+    },
+    {
+      "ca_id": 6666,
+      "spell_id": 706187
+    },
+    {
+      "ca_id": 6670,
+      "spell_id": 560340
+    },
+    {
+      "ca_id": 6671,
+      "spell_id": 707744
+    },
+    {
+      "ca_id": 6672,
+      "spell_id": 301146
+    },
+    {
+      "ca_id": 6673,
+      "spell_id": 803114
+    },
+    {
+      "ca_id": 6675,
+      "spell_id": 706748
+    },
+    {
+      "ca_id": 6676,
+      "spell_id": 807206
+    },
+    {
+      "ca_id": 6679,
+      "spell_id": 706754
+    },
+    {
+      "ca_id": 6681,
+      "spell_id": 706564
+    },
+    {
+      "ca_id": 6682,
+      "spell_id": 706277
+    },
+    {
+      "ca_id": 6684,
+      "spell_id": 806125
+    },
+    {
+      "ca_id": 6685,
+      "spell_id": 504867
+    },
+    {
+      "ca_id": 6687,
+      "spell_id": 706025
+    },
+    {
+      "ca_id": 6689,
+      "spell_id": 801134
+    },
+    {
+      "ca_id": 6690,
+      "spell_id": 300876
+    },
+    {
+      "ca_id": 6693,
+      "spell_id": 804733
+    },
+    {
+      "ca_id": 6696,
+      "spell_id": 561310
+    },
+    {
+      "ca_id": 6697,
+      "spell_id": 706053
+    },
+    {
+      "ca_id": 6698,
+      "spell_id": 806165
+    },
+    {
+      "ca_id": 6699,
+      "spell_id": 706102
+    },
+    {
+      "ca_id": 6700,
+      "spell_id": 806338
+    },
+    {
+      "ca_id": 6702,
+      "spell_id": 804505
+    },
+    {
+      "ca_id": 6703,
+      "spell_id": 524939
+    },
+    {
+      "ca_id": 6706,
+      "spell_id": 561359
+    },
+    {
+      "ca_id": 6708,
+      "spell_id": 706790
+    },
+    {
+      "ca_id": 6709,
+      "spell_id": 707455
+    },
+    {
+      "ca_id": 6710,
+      "spell_id": 560490
+    },
+    {
+      "ca_id": 6712,
+      "spell_id": 706515
+    },
+    {
+      "ca_id": 6713,
+      "spell_id": 560938
+    },
+    {
+      "ca_id": 6716,
+      "spell_id": 561127
+    },
+    {
+      "ca_id": 6719,
+      "spell_id": 803990
+    },
+    {
+      "ca_id": 6722,
+      "spell_id": 804311
+    },
+    {
+      "ca_id": 6723,
+      "spell_id": 705441
+    },
+    {
+      "ca_id": 6724,
+      "spell_id": 705386
+    },
+    {
+      "ca_id": 6726,
+      "spell_id": 704558
+    },
+    {
+      "ca_id": 6730,
+      "spell_id": 706792
+    },
+    {
+      "ca_id": 6737,
+      "spell_id": 805927
+    },
+    {
+      "ca_id": 6739,
+      "spell_id": 804745
+    },
+    {
+      "ca_id": 6740,
+      "spell_id": 560910
+    },
+    {
+      "ca_id": 6741,
+      "spell_id": 520539
+    },
+    {
+      "ca_id": 6742,
+      "spell_id": 705173
+    },
+    {
+      "ca_id": 6744,
+      "spell_id": 705222
+    },
+    {
+      "ca_id": 6750,
+      "spell_id": 705167
+    },
+    {
+      "ca_id": 6753,
+      "spell_id": 560364
+    },
+    {
+      "ca_id": 6755,
+      "spell_id": 804004
+    },
+    {
+      "ca_id": 6756,
+      "spell_id": 704235
+    },
+    {
+      "ca_id": 6758,
+      "spell_id": 500582
+    },
+    {
+      "ca_id": 6762,
+      "spell_id": 704552
+    },
+    {
+      "ca_id": 6765,
+      "spell_id": 573040
+    },
+    {
+      "ca_id": 6766,
+      "spell_id": 801335
+    },
+    {
+      "ca_id": 6768,
+      "spell_id": 704356
+    },
+    {
+      "ca_id": 6769,
+      "spell_id": 704166
+    },
+    {
+      "ca_id": 6770,
+      "spell_id": 300250
+    },
+    {
+      "ca_id": 6771,
+      "spell_id": 560080
+    },
+    {
+      "ca_id": 6772,
+      "spell_id": 560492
+    },
+    {
+      "ca_id": 6774,
+      "spell_id": 705123
+    },
+    {
+      "ca_id": 6777,
+      "spell_id": 504309
+    },
+    {
+      "ca_id": 6778,
+      "spell_id": 704357
+    },
+    {
+      "ca_id": 6779,
+      "spell_id": 300569
+    },
+    {
+      "ca_id": 6780,
+      "spell_id": 560422
+    },
+    {
+      "ca_id": 6782,
+      "spell_id": 560495
+    },
+    {
+      "ca_id": 6785,
+      "spell_id": 805997
+    },
+    {
+      "ca_id": 6788,
+      "spell_id": 802335
+    },
+    {
+      "ca_id": 6790,
+      "spell_id": 706352
+    },
+    {
+      "ca_id": 6794,
+      "spell_id": 706558
+    },
+    {
+      "ca_id": 6796,
+      "spell_id": 560564
+    },
+    {
+      "ca_id": 6797,
+      "spell_id": 805893
+    },
+    {
+      "ca_id": 6798,
+      "spell_id": 705198
+    },
+    {
+      "ca_id": 6799,
+      "spell_id": 705227
+    },
+    {
+      "ca_id": 6801,
+      "spell_id": 707661
+    },
+    {
+      "ca_id": 6802,
+      "spell_id": 705202
+    },
+    {
+      "ca_id": 6803,
+      "spell_id": 705238
+    },
+    {
+      "ca_id": 6807,
+      "spell_id": 500166
+    },
+    {
+      "ca_id": 6812,
+      "spell_id": 704745
+    },
+    {
+      "ca_id": 6815,
+      "spell_id": 520240
+    },
+    {
+      "ca_id": 6816,
+      "spell_id": 300723
+    },
+    {
+      "ca_id": 6817,
+      "spell_id": 300542
+    },
+    {
+      "ca_id": 6818,
+      "spell_id": 706806
+    },
+    {
+      "ca_id": 6825,
+      "spell_id": 705632
+    },
+    {
+      "ca_id": 6826,
+      "spell_id": 803347
+    },
+    {
+      "ca_id": 6828,
+      "spell_id": 801005
+    },
+    {
+      "ca_id": 6829,
+      "spell_id": 503534
+    },
+    {
+      "ca_id": 6831,
+      "spell_id": 704096
+    },
+    {
+      "ca_id": 6834,
+      "spell_id": 560450
+    },
+    {
+      "ca_id": 6837,
+      "spell_id": 805581
+    },
+    {
+      "ca_id": 6838,
+      "spell_id": 705432
+    },
+    {
+      "ca_id": 6839,
+      "spell_id": 560486
+    },
+    {
+      "ca_id": 6841,
+      "spell_id": 806293
+    },
+    {
+      "ca_id": 6842,
+      "spell_id": 706030
+    },
+    {
+      "ca_id": 6843,
+      "spell_id": 504393
+    },
+    {
+      "ca_id": 6844,
+      "spell_id": 800943
+    },
+    {
+      "ca_id": 6847,
+      "spell_id": 806421
+    },
+    {
+      "ca_id": 6848,
+      "spell_id": 553267
+    },
+    {
+      "ca_id": 6850,
+      "spell_id": 560023
+    },
+    {
+      "ca_id": 6851,
+      "spell_id": 300609
+    },
+    {
+      "ca_id": 6853,
+      "spell_id": 802268
+    },
+    {
+      "ca_id": 6856,
+      "spell_id": 800162
+    },
+    {
+      "ca_id": 6857,
+      "spell_id": 707317
+    },
+    {
+      "ca_id": 6858,
+      "spell_id": 705453
+    },
+    {
+      "ca_id": 6859,
+      "spell_id": 704992
+    },
+    {
+      "ca_id": 6860,
+      "spell_id": 707028
+    },
+    {
+      "ca_id": 6861,
+      "spell_id": 520009
+    },
+    {
+      "ca_id": 6862,
+      "spell_id": 560550
+    },
+    {
+      "ca_id": 6863,
+      "spell_id": 806149
+    },
+    {
+      "ca_id": 6865,
+      "spell_id": 806116
+    },
+    {
+      "ca_id": 6866,
+      "spell_id": 301267
+    },
+    {
+      "ca_id": 6868,
+      "spell_id": 805235
+    },
+    {
+      "ca_id": 6871,
+      "spell_id": 705196
+    },
+    {
+      "ca_id": 6875,
+      "spell_id": 705105
+    },
+    {
+      "ca_id": 6876,
+      "spell_id": 804822
+    },
+    {
+      "ca_id": 6877,
+      "spell_id": 300474
+    },
+    {
+      "ca_id": 6878,
+      "spell_id": 704563
+    },
+    {
+      "ca_id": 6879,
+      "spell_id": 560527
+    },
+    {
+      "ca_id": 6881,
+      "spell_id": 704627
+    },
+    {
+      "ca_id": 6883,
+      "spell_id": 707257
+    },
+    {
+      "ca_id": 6884,
+      "spell_id": 706077
+    },
+    {
+      "ca_id": 6885,
+      "spell_id": 300748
+    },
+    {
+      "ca_id": 6886,
+      "spell_id": 560595
+    },
+    {
+      "ca_id": 6887,
+      "spell_id": 705747
+    },
+    {
+      "ca_id": 6890,
+      "spell_id": 506632
+    },
+    {
+      "ca_id": 6891,
+      "spell_id": 801733
+    },
+    {
+      "ca_id": 6892,
+      "spell_id": 805649
+    },
+    {
+      "ca_id": 6893,
+      "spell_id": 704355
+    },
+    {
+      "ca_id": 6897,
+      "spell_id": 531128
+    },
+    {
+      "ca_id": 6900,
+      "spell_id": 807937
+    },
+    {
+      "ca_id": 6901,
+      "spell_id": 300940
+    },
+    {
+      "ca_id": 6903,
+      "spell_id": 705746
+    },
+    {
+      "ca_id": 6904,
+      "spell_id": 704528
+    },
+    {
+      "ca_id": 6906,
+      "spell_id": 704981
+    },
+    {
+      "ca_id": 6908,
+      "spell_id": 704475
+    },
+    {
+      "ca_id": 6909,
+      "spell_id": 805998
+    },
+    {
+      "ca_id": 6910,
+      "spell_id": 806235
+    },
+    {
+      "ca_id": 6911,
+      "spell_id": 520246
+    },
+    {
+      "ca_id": 6912,
+      "spell_id": 560838
+    },
+    {
+      "ca_id": 6914,
+      "spell_id": 560840
+    },
+    {
+      "ca_id": 6915,
+      "spell_id": 520236
+    },
+    {
+      "ca_id": 6919,
+      "spell_id": 704610
+    },
+    {
+      "ca_id": 6920,
+      "spell_id": 705285
+    },
+    {
+      "ca_id": 6921,
+      "spell_id": 806522
+    },
+    {
+      "ca_id": 6924,
+      "spell_id": 560116
+    },
+    {
+      "ca_id": 6928,
+      "spell_id": 560655
+    },
+    {
+      "ca_id": 6929,
+      "spell_id": 805693
+    },
+    {
+      "ca_id": 6931,
+      "spell_id": 704378
+    },
+    {
+      "ca_id": 6936,
+      "spell_id": 705015
+    },
+    {
+      "ca_id": 6938,
+      "spell_id": 560814
+    },
+    {
+      "ca_id": 6941,
+      "spell_id": 705033
+    },
+    {
+      "ca_id": 6944,
+      "spell_id": 560812
+    },
+    {
+      "ca_id": 6945,
+      "spell_id": 520585
+    },
+    {
+      "ca_id": 6946,
+      "spell_id": 520578
+    },
+    {
+      "ca_id": 6947,
+      "spell_id": 524864
+    },
+    {
+      "ca_id": 6948,
+      "spell_id": 301984
+    },
+    {
+      "ca_id": 6949,
+      "spell_id": 707432
+    },
+    {
+      "ca_id": 6950,
+      "spell_id": 800816
+    },
+    {
+      "ca_id": 6951,
+      "spell_id": 706860
+    },
+    {
+      "ca_id": 6952,
+      "spell_id": 801951
+    },
+    {
+      "ca_id": 6955,
+      "spell_id": 800086
+    },
+    {
+      "ca_id": 6957,
+      "spell_id": 707126
+    },
+    {
+      "ca_id": 6959,
+      "spell_id": 706189
+    },
+    {
+      "ca_id": 6960,
+      "spell_id": 300965
+    },
+    {
+      "ca_id": 6961,
+      "spell_id": 806324
+    },
+    {
+      "ca_id": 6962,
+      "spell_id": 524642
+    },
+    {
+      "ca_id": 6965,
+      "spell_id": 707113
+    },
+    {
+      "ca_id": 6966,
+      "spell_id": 807966
+    },
+    {
+      "ca_id": 6967,
+      "spell_id": 808009
+    },
+    {
+      "ca_id": 6968,
+      "spell_id": 705137
+    },
+    {
+      "ca_id": 6969,
+      "spell_id": 705817
+    },
+    {
+      "ca_id": 6971,
+      "spell_id": 502537
+    },
+    {
+      "ca_id": 6972,
+      "spell_id": 504918
+    },
+    {
+      "ca_id": 6973,
+      "spell_id": 505230
+    },
+    {
+      "ca_id": 6974,
+      "spell_id": 300877
+    },
+    {
+      "ca_id": 6975,
+      "spell_id": 801709
+    },
+    {
+      "ca_id": 6976,
+      "spell_id": 560787
+    },
+    {
+      "ca_id": 6977,
+      "spell_id": 560782
+    },
+    {
+      "ca_id": 6979,
+      "spell_id": 560744
+    },
+    {
+      "ca_id": 6982,
+      "spell_id": 807307
+    },
+    {
+      "ca_id": 6983,
+      "spell_id": 802262
+    },
+    {
+      "ca_id": 6984,
+      "spell_id": 525018
+    },
+    {
+      "ca_id": 6985,
+      "spell_id": 800791
+    },
+    {
+      "ca_id": 6986,
+      "spell_id": 300751
+    },
+    {
+      "ca_id": 6987,
+      "spell_id": 706889
+    },
+    {
+      "ca_id": 6989,
+      "spell_id": 504531
+    },
+    {
+      "ca_id": 6990,
+      "spell_id": 504530
+    },
+    {
+      "ca_id": 6991,
+      "spell_id": 653245
+    },
+    {
+      "ca_id": 6992,
+      "spell_id": 705810
+    },
+    {
+      "ca_id": 6996,
+      "spell_id": 705805
+    },
+    {
+      "ca_id": 6998,
+      "spell_id": 706375
+    },
+    {
+      "ca_id": 7001,
+      "spell_id": 500535
+    },
+    {
+      "ca_id": 7002,
+      "spell_id": 802963
+    },
+    {
+      "ca_id": 7004,
+      "spell_id": 500249
+    },
+    {
+      "ca_id": 7006,
+      "spell_id": 800811
+    },
+    {
+      "ca_id": 7008,
+      "spell_id": 704807
+    },
+    {
+      "ca_id": 7009,
+      "spell_id": 560525
+    },
+    {
+      "ca_id": 7010,
+      "spell_id": 706893
+    },
+    {
+      "ca_id": 7013,
+      "spell_id": 706680
+    },
+    {
+      "ca_id": 7014,
+      "spell_id": 503568
+    },
+    {
+      "ca_id": 7015,
+      "spell_id": 503569
+    },
+    {
+      "ca_id": 7018,
+      "spell_id": 504523
+    },
+    {
+      "ca_id": 7021,
+      "spell_id": 520022
+    },
+    {
+      "ca_id": 7024,
+      "spell_id": 705291
+    },
+    {
+      "ca_id": 7027,
+      "spell_id": 680788
+    },
+    {
+      "ca_id": 7029,
+      "spell_id": 705668
+    },
+    {
+      "ca_id": 7031,
+      "spell_id": 503707
+    },
+    {
+      "ca_id": 7033,
+      "spell_id": 503774
+    },
+    {
+      "ca_id": 7034,
+      "spell_id": 705831
+    },
+    {
+      "ca_id": 7035,
+      "spell_id": 705820
+    },
+    {
+      "ca_id": 7037,
+      "spell_id": 805372
+    },
+    {
+      "ca_id": 7038,
+      "spell_id": 300972
+    },
+    {
+      "ca_id": 7040,
+      "spell_id": 705350
+    },
+    {
+      "ca_id": 7041,
+      "spell_id": 807159
+    },
+    {
+      "ca_id": 7042,
+      "spell_id": 806148
+    },
+    {
+      "ca_id": 7043,
+      "spell_id": 704804
+    },
+    {
+      "ca_id": 7045,
+      "spell_id": 707325
+    },
+    {
+      "ca_id": 7047,
+      "spell_id": 803074
+    },
+    {
+      "ca_id": 7048,
+      "spell_id": 803871
+    },
+    {
+      "ca_id": 7050,
+      "spell_id": 573042
+    },
+    {
+      "ca_id": 7052,
+      "spell_id": 300306
+    },
+    {
+      "ca_id": 7056,
+      "spell_id": 805572
+    },
+    {
+      "ca_id": 7057,
+      "spell_id": 802048
+    },
+    {
+      "ca_id": 7058,
+      "spell_id": 500719
+    },
+    {
+      "ca_id": 7061,
+      "spell_id": 680503
+    },
+    {
+      "ca_id": 7063,
+      "spell_id": 572770
+    },
+    {
+      "ca_id": 7064,
+      "spell_id": 681100
+    },
+    {
+      "ca_id": 7066,
+      "spell_id": 503662
+    },
+    {
+      "ca_id": 7068,
+      "spell_id": 705478
+    },
+    {
+      "ca_id": 7071,
+      "spell_id": 560526
+    },
+    {
+      "ca_id": 7072,
+      "spell_id": 706921
+    },
+    {
+      "ca_id": 7074,
+      "spell_id": 504470
+    },
+    {
+      "ca_id": 7075,
+      "spell_id": 705515
+    },
+    {
+      "ca_id": 7077,
+      "spell_id": 705490
+    },
+    {
+      "ca_id": 7078,
+      "spell_id": 805751
+    },
+    {
+      "ca_id": 7083,
+      "spell_id": 504642
+    },
+    {
+      "ca_id": 7084,
+      "spell_id": 560715
+    },
+    {
+      "ca_id": 7085,
+      "spell_id": 707078
+    },
+    {
+      "ca_id": 7086,
+      "spell_id": 801607
+    },
+    {
+      "ca_id": 7088,
+      "spell_id": 503608
+    },
+    {
+      "ca_id": 7092,
+      "spell_id": 705880
+    },
+    {
+      "ca_id": 7093,
+      "spell_id": 524812
+    },
+    {
+      "ca_id": 7095,
+      "spell_id": 805770
+    },
+    {
+      "ca_id": 7096,
+      "spell_id": 504677
+    },
+    {
+      "ca_id": 7097,
+      "spell_id": 802020
+    },
+    {
+      "ca_id": 7099,
+      "spell_id": 801063
+    },
+    {
+      "ca_id": 7100,
+      "spell_id": 707331
+    },
+    {
+      "ca_id": 7102,
+      "spell_id": 807040
+    },
+    {
+      "ca_id": 7103,
+      "spell_id": 681242
+    },
+    {
+      "ca_id": 7105,
+      "spell_id": 802494
+    },
+    {
+      "ca_id": 7107,
+      "spell_id": 805107
+    },
+    {
+      "ca_id": 7108,
+      "spell_id": 503721
+    },
+    {
+      "ca_id": 7109,
+      "spell_id": 801234
+    },
+    {
+      "ca_id": 7112,
+      "spell_id": 560596
+    },
+    {
+      "ca_id": 7117,
+      "spell_id": 504431
+    },
+    {
+      "ca_id": 7119,
+      "spell_id": 503740
+    },
+    {
+      "ca_id": 7120,
+      "spell_id": 706014
+    },
+    {
+      "ca_id": 7121,
+      "spell_id": 706938
+    },
+    {
+      "ca_id": 7122,
+      "spell_id": 504348
+    },
+    {
+      "ca_id": 7123,
+      "spell_id": 300959
+    },
+    {
+      "ca_id": 7124,
+      "spell_id": 504356
+    },
+    {
+      "ca_id": 7128,
+      "spell_id": 802710
+    },
+    {
+      "ca_id": 7129,
+      "spell_id": 803463
+    },
+    {
+      "ca_id": 7130,
+      "spell_id": 504424
+    },
+    {
+      "ca_id": 7131,
+      "spell_id": 503748
+    },
+    {
+      "ca_id": 7132,
+      "spell_id": 503750
+    },
+    {
+      "ca_id": 7133,
+      "spell_id": 500053
+    },
+    {
+      "ca_id": 7141,
+      "spell_id": 805038
+    },
+    {
+      "ca_id": 7143,
+      "spell_id": 707175
+    },
+    {
+      "ca_id": 7145,
+      "spell_id": 707445
+    },
+    {
+      "ca_id": 7146,
+      "spell_id": 302518
+    },
+    {
+      "ca_id": 7147,
+      "spell_id": 706027
+    },
+    {
+      "ca_id": 7150,
+      "spell_id": 806603
+    },
+    {
+      "ca_id": 7152,
+      "spell_id": 706962
+    },
+    {
+      "ca_id": 7154,
+      "spell_id": 504426
+    },
+    {
+      "ca_id": 7157,
+      "spell_id": 807042
+    },
+    {
+      "ca_id": 7159,
+      "spell_id": 680946
+    },
+    {
+      "ca_id": 7160,
+      "spell_id": 504400
+    },
+    {
+      "ca_id": 7166,
+      "spell_id": 300680
+    },
+    {
+      "ca_id": 7169,
+      "spell_id": 560248
+    },
+    {
+      "ca_id": 7170,
+      "spell_id": 803197
+    },
+    {
+      "ca_id": 7171,
+      "spell_id": 300757
+    },
+    {
+      "ca_id": 7174,
+      "spell_id": 520019
+    },
+    {
+      "ca_id": 7175,
+      "spell_id": 538441
+    },
+    {
+      "ca_id": 7176,
+      "spell_id": 704856
+    },
+    {
+      "ca_id": 7177,
+      "spell_id": 803210
+    },
+    {
+      "ca_id": 7180,
+      "spell_id": 531515
+    },
+    {
+      "ca_id": 7184,
+      "spell_id": 573436
+    },
+    {
+      "ca_id": 7186,
+      "spell_id": 705708
+    },
+    {
+      "ca_id": 7188,
+      "spell_id": 707668
+    },
+    {
+      "ca_id": 7189,
+      "spell_id": 630900
+    },
+    {
+      "ca_id": 7190,
+      "spell_id": 503851
+    },
+    {
+      "ca_id": 7191,
+      "spell_id": 500230
+    },
+    {
+      "ca_id": 7192,
+      "spell_id": 574353
+    },
+    {
+      "ca_id": 7195,
+      "spell_id": 805104
+    },
+    {
+      "ca_id": 7196,
+      "spell_id": 704849
+    },
+    {
+      "ca_id": 7198,
+      "spell_id": 706777
+    },
+    {
+      "ca_id": 7200,
+      "spell_id": 806335
+    },
+    {
+      "ca_id": 7201,
+      "spell_id": 801292
+    },
+    {
+      "ca_id": 7202,
+      "spell_id": 802170
+    },
+    {
+      "ca_id": 7203,
+      "spell_id": 802169
+    },
+    {
+      "ca_id": 7204,
+      "spell_id": 805933
+    },
+    {
+      "ca_id": 7209,
+      "spell_id": 707555
+    },
+    {
+      "ca_id": 7210,
+      "spell_id": 504344
+    },
+    {
+      "ca_id": 7213,
+      "spell_id": 504357
+    },
+    {
+      "ca_id": 7214,
+      "spell_id": 801739
+    },
+    {
+      "ca_id": 7215,
+      "spell_id": 706023
+    },
+    {
+      "ca_id": 7216,
+      "spell_id": 707556
+    },
+    {
+      "ca_id": 7217,
+      "spell_id": 706945
+    },
+    {
+      "ca_id": 7219,
+      "spell_id": 706942
+    },
+    {
+      "ca_id": 7222,
+      "spell_id": 573307
+    },
+    {
+      "ca_id": 7223,
+      "spell_id": 706937
+    },
+    {
+      "ca_id": 7225,
+      "spell_id": 681054
+    },
+    {
+      "ca_id": 7226,
+      "spell_id": 706084
+    },
+    {
+      "ca_id": 7229,
+      "spell_id": 804968
+    },
+    {
+      "ca_id": 7231,
+      "spell_id": 680794
+    },
+    {
+      "ca_id": 7235,
+      "spell_id": 705993
+    },
+    {
+      "ca_id": 7237,
+      "spell_id": 504406
+    },
+    {
+      "ca_id": 7241,
+      "spell_id": 560188
+    },
+    {
+      "ca_id": 7242,
+      "spell_id": 804978
+    },
+    {
+      "ca_id": 7244,
+      "spell_id": 503976
+    },
+    {
+      "ca_id": 7247,
+      "spell_id": 504326
+    },
+    {
+      "ca_id": 7248,
+      "spell_id": 705949
+    },
+    {
+      "ca_id": 7249,
+      "spell_id": 800901
+    },
+    {
+      "ca_id": 7252,
+      "spell_id": 800887
+    },
+    {
+      "ca_id": 7254,
+      "spell_id": 801123
+    },
+    {
+      "ca_id": 7256,
+      "spell_id": 520482
+    },
+    {
+      "ca_id": 7258,
+      "spell_id": 504329
+    },
+    {
+      "ca_id": 7259,
+      "spell_id": 705418
+    },
+    {
+      "ca_id": 7263,
+      "spell_id": 503854
+    },
+    {
+      "ca_id": 7264,
+      "spell_id": 503799
+    },
+    {
+      "ca_id": 7266,
+      "spell_id": 706785
+    },
+    {
+      "ca_id": 7267,
+      "spell_id": 504269
+    },
+    {
+      "ca_id": 7271,
+      "spell_id": 803999
+    },
+    {
+      "ca_id": 7272,
+      "spell_id": 706786
+    },
+    {
+      "ca_id": 7278,
+      "spell_id": 301262
+    },
+    {
+      "ca_id": 7280,
+      "spell_id": 300363
+    },
+    {
+      "ca_id": 7281,
+      "spell_id": 806477
+    },
+    {
+      "ca_id": 7283,
+      "spell_id": 504088
+    },
+    {
+      "ca_id": 7285,
+      "spell_id": 805035
+    },
+    {
+      "ca_id": 7287,
+      "spell_id": 681304
+    },
+    {
+      "ca_id": 7288,
+      "spell_id": 807774
+    },
+    {
+      "ca_id": 7289,
+      "spell_id": 704635
+    },
+    {
+      "ca_id": 7293,
+      "spell_id": 802576
+    },
+    {
+      "ca_id": 7294,
+      "spell_id": 704644
+    },
+    {
+      "ca_id": 7295,
+      "spell_id": 504241
+    },
+    {
+      "ca_id": 7297,
+      "spell_id": 806212
+    },
+    {
+      "ca_id": 7298,
+      "spell_id": 525600
+    },
+    {
+      "ca_id": 7303,
+      "spell_id": 523727
+    },
+    {
+      "ca_id": 7304,
+      "spell_id": 560259
+    },
+    {
+      "ca_id": 7305,
+      "spell_id": 704641
+    },
+    {
+      "ca_id": 7306,
+      "spell_id": 802299
+    },
+    {
+      "ca_id": 7307,
+      "spell_id": 500463
+    },
+    {
+      "ca_id": 7309,
+      "spell_id": 504144
+    },
+    {
+      "ca_id": 7310,
+      "spell_id": 300983
+    },
+    {
+      "ca_id": 7311,
+      "spell_id": 802296
+    },
+    {
+      "ca_id": 7314,
+      "spell_id": 805583
+    },
+    {
+      "ca_id": 7315,
+      "spell_id": 705389
+    },
+    {
+      "ca_id": 7318,
+      "spell_id": 504116
+    },
+    {
+      "ca_id": 7319,
+      "spell_id": 800654
+    },
+    {
+      "ca_id": 7320,
+      "spell_id": 560093
+    },
+    {
+      "ca_id": 7321,
+      "spell_id": 503630
+    },
+    {
+      "ca_id": 7322,
+      "spell_id": 504198
+    },
+    {
+      "ca_id": 7323,
+      "spell_id": 524971
+    },
+    {
+      "ca_id": 7326,
+      "spell_id": 806533
+    },
+    {
+      "ca_id": 7327,
+      "spell_id": 802782
+    },
+    {
+      "ca_id": 7330,
+      "spell_id": 504226
+    },
+    {
+      "ca_id": 7332,
+      "spell_id": 806549
+    },
+    {
+      "ca_id": 7333,
+      "spell_id": 805105
+    },
+    {
+      "ca_id": 7334,
+      "spell_id": 574313
+    },
+    {
+      "ca_id": 7335,
+      "spell_id": 303014
+    },
+    {
+      "ca_id": 7337,
+      "spell_id": 707584
+    },
+    {
+      "ca_id": 7338,
+      "spell_id": 705235
+    },
+    {
+      "ca_id": 7339,
+      "spell_id": 706167
+    },
+    {
+      "ca_id": 7342,
+      "spell_id": 706619
+    },
+    {
+      "ca_id": 7343,
+      "spell_id": 570027
+    },
+    {
+      "ca_id": 7345,
+      "spell_id": 805040
+    },
+    {
+      "ca_id": 7346,
+      "spell_id": 570046
+    },
+    {
+      "ca_id": 7347,
+      "spell_id": 531126
+    },
+    {
+      "ca_id": 7348,
+      "spell_id": 500989
+    },
+    {
+      "ca_id": 7350,
+      "spell_id": 503738
+    },
+    {
+      "ca_id": 7354,
+      "spell_id": 706258
+    },
+    {
+      "ca_id": 7355,
+      "spell_id": 560748
+    },
+    {
+      "ca_id": 7357,
+      "spell_id": 704402
+    },
+    {
+      "ca_id": 7358,
+      "spell_id": 800185
+    },
+    {
+      "ca_id": 7359,
+      "spell_id": 524922
+    },
+    {
+      "ca_id": 7360,
+      "spell_id": 704966
+    },
+    {
+      "ca_id": 7361,
+      "spell_id": 704452
+    },
+    {
+      "ca_id": 7363,
+      "spell_id": 500003
+    },
+    {
+      "ca_id": 7364,
+      "spell_id": 800997
+    },
+    {
+      "ca_id": 7365,
+      "spell_id": 704975
+    },
+    {
+      "ca_id": 7366,
+      "spell_id": 805793
+    },
+    {
+      "ca_id": 7367,
+      "spell_id": 302548
+    },
+    {
+      "ca_id": 7369,
+      "spell_id": 804628
+    },
+    {
+      "ca_id": 7370,
+      "spell_id": 681252
+    },
+    {
+      "ca_id": 7371,
+      "spell_id": 500933
+    },
+    {
+      "ca_id": 7373,
+      "spell_id": 500464
+    },
+    {
+      "ca_id": 7374,
+      "spell_id": 706531
+    },
+    {
+      "ca_id": 7375,
+      "spell_id": 705609
+    },
+    {
+      "ca_id": 7376,
+      "spell_id": 800736
+    },
+    {
+      "ca_id": 7377,
+      "spell_id": 705581
+    },
+    {
+      "ca_id": 7379,
+      "spell_id": 704662
+    },
+    {
+      "ca_id": 7382,
+      "spell_id": 803018
+    },
+    {
+      "ca_id": 7383,
+      "spell_id": 560951
+    },
+    {
+      "ca_id": 7384,
+      "spell_id": 680775
+    },
+    {
+      "ca_id": 7385,
+      "spell_id": 570001
+    },
+    {
+      "ca_id": 7386,
+      "spell_id": 806747
+    },
+    {
+      "ca_id": 7387,
+      "spell_id": 500167
+    },
+    {
+      "ca_id": 7388,
+      "spell_id": 805448
+    },
+    {
+      "ca_id": 7389,
+      "spell_id": 680378
+    },
+    {
+      "ca_id": 7391,
+      "spell_id": 806167
+    },
+    {
+      "ca_id": 7394,
+      "spell_id": 806757
+    },
+    {
+      "ca_id": 7395,
+      "spell_id": 800349
+    },
+    {
+      "ca_id": 7396,
+      "spell_id": 806758
+    },
+    {
+      "ca_id": 7397,
+      "spell_id": 704585
+    },
+    {
+      "ca_id": 7402,
+      "spell_id": 805303
+    },
+    {
+      "ca_id": 7404,
+      "spell_id": 524876
+    },
+    {
+      "ca_id": 7406,
+      "spell_id": 680215
+    },
+    {
+      "ca_id": 7407,
+      "spell_id": 680704
+    },
+    {
+      "ca_id": 7408,
+      "spell_id": 705005
+    },
+    {
+      "ca_id": 7409,
+      "spell_id": 800505
+    },
+    {
+      "ca_id": 7410,
+      "spell_id": 707639
+    },
+    {
+      "ca_id": 7411,
+      "spell_id": 681190
+    },
+    {
+      "ca_id": 7413,
+      "spell_id": 704798
+    },
+    {
+      "ca_id": 7414,
+      "spell_id": 807918
+    },
+    {
+      "ca_id": 7415,
+      "spell_id": 680236
+    },
+    {
+      "ca_id": 7416,
+      "spell_id": 705531
+    },
+    {
+      "ca_id": 7417,
+      "spell_id": 520270
+    },
+    {
+      "ca_id": 7418,
+      "spell_id": 681180
+    },
+    {
+      "ca_id": 7420,
+      "spell_id": 680247
+    },
+    {
+      "ca_id": 7422,
+      "spell_id": 805738
+    },
+    {
+      "ca_id": 7424,
+      "spell_id": 804185
+    },
+    {
+      "ca_id": 7427,
+      "spell_id": 500056
+    },
+    {
+      "ca_id": 7428,
+      "spell_id": 500617
+    },
+    {
+      "ca_id": 7429,
+      "spell_id": 803104
+    },
+    {
+      "ca_id": 7430,
+      "spell_id": 504742
+    },
+    {
+      "ca_id": 7432,
+      "spell_id": 705145
+    },
+    {
+      "ca_id": 7433,
+      "spell_id": 681403
+    },
+    {
+      "ca_id": 7434,
+      "spell_id": 706256
+    },
+    {
+      "ca_id": 7435,
+      "spell_id": 681336
+    },
+    {
+      "ca_id": 7436,
+      "spell_id": 806274
+    },
+    {
+      "ca_id": 7437,
+      "spell_id": 806049
+    },
+    {
+      "ca_id": 7438,
+      "spell_id": 680732
+    },
+    {
+      "ca_id": 7439,
+      "spell_id": 704633
+    },
+    {
+      "ca_id": 7440,
+      "spell_id": 807490
+    },
+    {
+      "ca_id": 7443,
+      "spell_id": 706598
+    },
+    {
+      "ca_id": 7444,
+      "spell_id": 806424
+    },
+    {
+      "ca_id": 7445,
+      "spell_id": 803681
+    },
+    {
+      "ca_id": 7447,
+      "spell_id": 504275
+    },
+    {
+      "ca_id": 7448,
+      "spell_id": 680730
+    },
+    {
+      "ca_id": 7449,
+      "spell_id": 680731
+    },
+    {
+      "ca_id": 7450,
+      "spell_id": 504282
+    },
+    {
+      "ca_id": 7451,
+      "spell_id": 681169
+    },
+    {
+      "ca_id": 7452,
+      "spell_id": 560264
+    },
+    {
+      "ca_id": 7453,
+      "spell_id": 705961
+    },
+    {
+      "ca_id": 7455,
+      "spell_id": 705973
+    },
+    {
+      "ca_id": 7456,
+      "spell_id": 500086
+    },
+    {
+      "ca_id": 7458,
+      "spell_id": 706240
+    },
+    {
+      "ca_id": 7459,
+      "spell_id": 520670
+    },
+    {
+      "ca_id": 7460,
+      "spell_id": 680331
+    },
+    {
+      "ca_id": 7461,
+      "spell_id": 500055
+    },
+    {
+      "ca_id": 7463,
+      "spell_id": 802315
+    },
+    {
+      "ca_id": 7465,
+      "spell_id": 706188
+    },
+    {
+      "ca_id": 7473,
+      "spell_id": 560030
+    },
+    {
+      "ca_id": 7474,
+      "spell_id": 681110
+    },
+    {
+      "ca_id": 7478,
+      "spell_id": 706859
+    },
+    {
+      "ca_id": 7479,
+      "spell_id": 680369
+    },
+    {
+      "ca_id": 7481,
+      "spell_id": 805477
+    },
+    {
+      "ca_id": 7482,
+      "spell_id": 705533
+    },
+    {
+      "ca_id": 7483,
+      "spell_id": 803219
+    },
+    {
+      "ca_id": 7486,
+      "spell_id": 804930
+    },
+    {
+      "ca_id": 7487,
+      "spell_id": 680409
+    },
+    {
+      "ca_id": 7488,
+      "spell_id": 803974
+    },
+    {
+      "ca_id": 7492,
+      "spell_id": 300695
+    },
+    {
+      "ca_id": 7493,
+      "spell_id": 681130
+    },
+    {
+      "ca_id": 7494,
+      "spell_id": 680964
+    },
+    {
+      "ca_id": 7498,
+      "spell_id": 300693
+    },
+    {
+      "ca_id": 7499,
+      "spell_id": 706220
+    },
+    {
+      "ca_id": 7500,
+      "spell_id": 560548
+    },
+    {
+      "ca_id": 7501,
+      "spell_id": 570157
+    },
+    {
+      "ca_id": 7502,
+      "spell_id": 560505
+    },
+    {
+      "ca_id": 7503,
+      "spell_id": 805643
+    },
+    {
+      "ca_id": 7505,
+      "spell_id": 560298
+    },
+    {
+      "ca_id": 7506,
+      "spell_id": 680408
+    },
+    {
+      "ca_id": 7507,
+      "spell_id": 680413
+    },
+    {
+      "ca_id": 7508,
+      "spell_id": 680404
+    },
+    {
+      "ca_id": 7510,
+      "spell_id": 680410
+    },
+    {
+      "ca_id": 7512,
+      "spell_id": 680750
+    },
+    {
+      "ca_id": 7513,
+      "spell_id": 560147
+    },
+    {
+      "ca_id": 7514,
+      "spell_id": 706161
+    },
+    {
+      "ca_id": 7515,
+      "spell_id": 680415
+    },
+    {
+      "ca_id": 7516,
+      "spell_id": 681364
+    },
+    {
+      "ca_id": 7517,
+      "spell_id": 680412
+    },
+    {
+      "ca_id": 7518,
+      "spell_id": 680421
+    },
+    {
+      "ca_id": 7519,
+      "spell_id": 806185
+    },
+    {
+      "ca_id": 7520,
+      "spell_id": 560150
+    },
+    {
+      "ca_id": 7521,
+      "spell_id": 560508
+    },
+    {
+      "ca_id": 7524,
+      "spell_id": 300728
+    },
+    {
+      "ca_id": 7525,
+      "spell_id": 680424
+    },
+    {
+      "ca_id": 7527,
+      "spell_id": 680405
+    },
+    {
+      "ca_id": 7528,
+      "spell_id": 706622
+    },
+    {
+      "ca_id": 7531,
+      "spell_id": 560154
+    },
+    {
+      "ca_id": 7532,
+      "spell_id": 680444
+    },
+    {
+      "ca_id": 7533,
+      "spell_id": 681494
+    },
+    {
+      "ca_id": 7535,
+      "spell_id": 680442
+    },
+    {
+      "ca_id": 7537,
+      "spell_id": 574314
+    },
+    {
+      "ca_id": 7538,
+      "spell_id": 805335
+    },
+    {
+      "ca_id": 7543,
+      "spell_id": 707173
+    },
+    {
+      "ca_id": 7545,
+      "spell_id": 560169
+    },
+    {
+      "ca_id": 7547,
+      "spell_id": 706208
+    },
+    {
+      "ca_id": 7548,
+      "spell_id": 560157
+    },
+    {
+      "ca_id": 7551,
+      "spell_id": 524873
+    },
+    {
+      "ca_id": 7553,
+      "spell_id": 707064
+    },
+    {
+      "ca_id": 7554,
+      "spell_id": 560320
+    },
+    {
+      "ca_id": 7555,
+      "spell_id": 500704
+    },
+    {
+      "ca_id": 7556,
+      "spell_id": 561035
+    },
+    {
+      "ca_id": 7557,
+      "spell_id": 681106
+    },
+    {
+      "ca_id": 7558,
+      "spell_id": 681104
+    },
+    {
+      "ca_id": 7559,
+      "spell_id": 802728
+    },
+    {
+      "ca_id": 7563,
+      "spell_id": 301180
+    },
+    {
+      "ca_id": 7564,
+      "spell_id": 805117
+    },
+    {
+      "ca_id": 7565,
+      "spell_id": 806768
+    },
+    {
+      "ca_id": 7569,
+      "spell_id": 802280
+    },
+    {
+      "ca_id": 7571,
+      "spell_id": 503659
+    },
+    {
+      "ca_id": 7574,
+      "spell_id": 680516
+    },
+    {
+      "ca_id": 7575,
+      "spell_id": 681095
+    },
+    {
+      "ca_id": 7577,
+      "spell_id": 680494
+    },
+    {
+      "ca_id": 7580,
+      "spell_id": 707407
+    },
+    {
+      "ca_id": 7582,
+      "spell_id": 805346
+    },
+    {
+      "ca_id": 7583,
+      "spell_id": 680496
+    },
+    {
+      "ca_id": 7584,
+      "spell_id": 680521
+    },
+    {
+      "ca_id": 7585,
+      "spell_id": 680528
+    },
+    {
+      "ca_id": 7586,
+      "spell_id": 680518
+    },
+    {
+      "ca_id": 7587,
+      "spell_id": 680492
+    },
+    {
+      "ca_id": 7588,
+      "spell_id": 681156
+    },
+    {
+      "ca_id": 7589,
+      "spell_id": 680504
+    },
+    {
+      "ca_id": 7590,
+      "spell_id": 705519
+    },
+    {
+      "ca_id": 7591,
+      "spell_id": 680513
+    },
+    {
+      "ca_id": 7592,
+      "spell_id": 707067
+    },
+    {
+      "ca_id": 7594,
+      "spell_id": 681098
+    },
+    {
+      "ca_id": 7595,
+      "spell_id": 680525
+    },
+    {
+      "ca_id": 7596,
+      "spell_id": 680599
+    },
+    {
+      "ca_id": 7597,
+      "spell_id": 680530
+    },
+    {
+      "ca_id": 7598,
+      "spell_id": 300575
+    },
+    {
+      "ca_id": 7599,
+      "spell_id": 301338
+    },
+    {
+      "ca_id": 7601,
+      "spell_id": 503664
+    },
+    {
+      "ca_id": 7604,
+      "spell_id": 680544
+    },
+    {
+      "ca_id": 7605,
+      "spell_id": 680538
+    },
+    {
+      "ca_id": 7606,
+      "spell_id": 560091
+    },
+    {
+      "ca_id": 7608,
+      "spell_id": 804670
+    },
+    {
+      "ca_id": 7609,
+      "spell_id": 524804
+    },
+    {
+      "ca_id": 7610,
+      "spell_id": 560002
+    },
+    {
+      "ca_id": 7611,
+      "spell_id": 300272
+    },
+    {
+      "ca_id": 7612,
+      "spell_id": 300268
+    },
+    {
+      "ca_id": 7614,
+      "spell_id": 802043
+    },
+    {
+      "ca_id": 7615,
+      "spell_id": 560502
+    },
+    {
+      "ca_id": 7616,
+      "spell_id": 680581
+    },
+    {
+      "ca_id": 7617,
+      "spell_id": 680558
+    },
+    {
+      "ca_id": 7618,
+      "spell_id": 680555
+    },
+    {
+      "ca_id": 7619,
+      "spell_id": 582308
+    },
+    {
+      "ca_id": 7620,
+      "spell_id": 300278
+    },
+    {
+      "ca_id": 7621,
+      "spell_id": 801968
+    },
+    {
+      "ca_id": 7622,
+      "spell_id": 680579
+    },
+    {
+      "ca_id": 7624,
+      "spell_id": 681425
+    },
+    {
+      "ca_id": 7625,
+      "spell_id": 680570
+    },
+    {
+      "ca_id": 7626,
+      "spell_id": 681088
+    },
+    {
+      "ca_id": 7627,
+      "spell_id": 680575
+    },
+    {
+      "ca_id": 7629,
+      "spell_id": 681474
+    },
+    {
+      "ca_id": 7630,
+      "spell_id": 520277
+    },
+    {
+      "ca_id": 7632,
+      "spell_id": 680650
+    },
+    {
+      "ca_id": 7633,
+      "spell_id": 804051
+    },
+    {
+      "ca_id": 7635,
+      "spell_id": 704932
+    },
+    {
+      "ca_id": 7636,
+      "spell_id": 301313
+    },
+    {
+      "ca_id": 7637,
+      "spell_id": 704934
+    },
+    {
+      "ca_id": 7638,
+      "spell_id": 806699
+    },
+    {
+      "ca_id": 7639,
+      "spell_id": 680620
+    },
+    {
+      "ca_id": 7640,
+      "spell_id": 520359
+    },
+    {
+      "ca_id": 7642,
+      "spell_id": 300318
+    },
+    {
+      "ca_id": 7644,
+      "spell_id": 680624
+    },
+    {
+      "ca_id": 7646,
+      "spell_id": 680663
+    },
+    {
+      "ca_id": 7647,
+      "spell_id": 805267
+    },
+    {
+      "ca_id": 7649,
+      "spell_id": 680621
+    },
+    {
+      "ca_id": 7651,
+      "spell_id": 680641
+    },
+    {
+      "ca_id": 7652,
+      "spell_id": 704903
+    },
+    {
+      "ca_id": 7653,
+      "spell_id": 681253
+    },
+    {
+      "ca_id": 7655,
+      "spell_id": 680648
+    },
+    {
+      "ca_id": 7656,
+      "spell_id": 680646
+    },
+    {
+      "ca_id": 7657,
+      "spell_id": 704928
+    },
+    {
+      "ca_id": 7658,
+      "spell_id": 800039
+    },
+    {
+      "ca_id": 7659,
+      "spell_id": 680647
+    },
+    {
+      "ca_id": 7661,
+      "spell_id": 680657
+    },
+    {
+      "ca_id": 7662,
+      "spell_id": 704659
+    },
+    {
+      "ca_id": 7664,
+      "spell_id": 704936
+    },
+    {
+      "ca_id": 7665,
+      "spell_id": 680645
+    },
+    {
+      "ca_id": 7666,
+      "spell_id": 804751
+    },
+    {
+      "ca_id": 7668,
+      "spell_id": 680695
+    },
+    {
+      "ca_id": 7669,
+      "spell_id": 681077
+    },
+    {
+      "ca_id": 7670,
+      "spell_id": 800780
+    },
+    {
+      "ca_id": 7672,
+      "spell_id": 560249
+    },
+    {
+      "ca_id": 7674,
+      "spell_id": 806944
+    },
+    {
+      "ca_id": 7676,
+      "spell_id": 504071
+    },
+    {
+      "ca_id": 7677,
+      "spell_id": 800781
+    },
+    {
+      "ca_id": 7679,
+      "spell_id": 680675
+    },
+    {
+      "ca_id": 7680,
+      "spell_id": 680823
+    },
+    {
+      "ca_id": 7681,
+      "spell_id": 706603
+    },
+    {
+      "ca_id": 7684,
+      "spell_id": 680773
+    },
+    {
+      "ca_id": 7685,
+      "spell_id": 680711
+    },
+    {
+      "ca_id": 7686,
+      "spell_id": 704603
+    },
+    {
+      "ca_id": 7687,
+      "spell_id": 680770
+    },
+    {
+      "ca_id": 7690,
+      "spell_id": 680212
+    },
+    {
+      "ca_id": 7691,
+      "spell_id": 804805
+    },
+    {
+      "ca_id": 7692,
+      "spell_id": 680771
+    },
+    {
+      "ca_id": 7694,
+      "spell_id": 804807
+    },
+    {
+      "ca_id": 7695,
+      "spell_id": 680733
+    },
+    {
+      "ca_id": 7697,
+      "spell_id": 704389
+    },
+    {
+      "ca_id": 7698,
+      "spell_id": 680774
+    },
+    {
+      "ca_id": 7699,
+      "spell_id": 680708
+    },
+    {
+      "ca_id": 7700,
+      "spell_id": 680777
+    },
+    {
+      "ca_id": 7701,
+      "spell_id": 704793
+    },
+    {
+      "ca_id": 7702,
+      "spell_id": 802680
+    },
+    {
+      "ca_id": 7703,
+      "spell_id": 560319
+    },
+    {
+      "ca_id": 7704,
+      "spell_id": 560501
+    },
+    {
+      "ca_id": 7705,
+      "spell_id": 680786
+    },
+    {
+      "ca_id": 7706,
+      "spell_id": 704787
+    },
+    {
+      "ca_id": 7707,
+      "spell_id": 805505
+    },
+    {
+      "ca_id": 7708,
+      "spell_id": 680738
+    },
+    {
+      "ca_id": 7709,
+      "spell_id": 680737
+    },
+    {
+      "ca_id": 7712,
+      "spell_id": 680742
+    },
+    {
+      "ca_id": 7713,
+      "spell_id": 804385
+    },
+    {
+      "ca_id": 7714,
+      "spell_id": 804254
+    },
+    {
+      "ca_id": 7715,
+      "spell_id": 680791
+    },
+    {
+      "ca_id": 7717,
+      "spell_id": 680755
+    },
+    {
+      "ca_id": 7718,
+      "spell_id": 300344
+    },
+    {
+      "ca_id": 7719,
+      "spell_id": 804257
+    },
+    {
+      "ca_id": 7720,
+      "spell_id": 560883
+    },
+    {
+      "ca_id": 7721,
+      "spell_id": 704604
+    },
+    {
+      "ca_id": 7722,
+      "spell_id": 800902
+    },
+    {
+      "ca_id": 7723,
+      "spell_id": 706016
+    },
+    {
+      "ca_id": 7724,
+      "spell_id": 680763
+    },
+    {
+      "ca_id": 7726,
+      "spell_id": 800910
+    },
+    {
+      "ca_id": 7727,
+      "spell_id": 707224
+    },
+    {
+      "ca_id": 7728,
+      "spell_id": 706455
+    },
+    {
+      "ca_id": 7730,
+      "spell_id": 504855
+    },
+    {
+      "ca_id": 7731,
+      "spell_id": 707233
+    },
+    {
+      "ca_id": 7732,
+      "spell_id": 681315
+    },
+    {
+      "ca_id": 7733,
+      "spell_id": 560195
+    },
+    {
+      "ca_id": 7734,
+      "spell_id": 706477
+    },
+    {
+      "ca_id": 7735,
+      "spell_id": 705957
+    },
+    {
+      "ca_id": 7736,
+      "spell_id": 706015
+    },
+    {
+      "ca_id": 7737,
+      "spell_id": 560200
+    },
+    {
+      "ca_id": 7738,
+      "spell_id": 680797
+    },
+    {
+      "ca_id": 7739,
+      "spell_id": 680801
+    },
+    {
+      "ca_id": 7740,
+      "spell_id": 524638
+    },
+    {
+      "ca_id": 7742,
+      "spell_id": 800504
+    },
+    {
+      "ca_id": 7743,
+      "spell_id": 500206
+    },
+    {
+      "ca_id": 7744,
+      "spell_id": 300995
+    },
+    {
+      "ca_id": 7746,
+      "spell_id": 561062
+    },
+    {
+      "ca_id": 7747,
+      "spell_id": 704739
+    },
+    {
+      "ca_id": 7748,
+      "spell_id": 680820
+    },
+    {
+      "ca_id": 7749,
+      "spell_id": 680822
+    },
+    {
+      "ca_id": 7750,
+      "spell_id": 505188
+    },
+    {
+      "ca_id": 7751,
+      "spell_id": 806428
+    },
+    {
+      "ca_id": 7752,
+      "spell_id": 680685
+    },
+    {
+      "ca_id": 7754,
+      "spell_id": 680828
+    },
+    {
+      "ca_id": 7757,
+      "spell_id": 504807
+    },
+    {
+      "ca_id": 7758,
+      "spell_id": 300515
+    },
+    {
+      "ca_id": 7760,
+      "spell_id": 706650
+    },
+    {
+      "ca_id": 7762,
+      "spell_id": 800776
+    },
+    {
+      "ca_id": 7763,
+      "spell_id": 301298
+    },
+    {
+      "ca_id": 7764,
+      "spell_id": 300497
+    },
+    {
+      "ca_id": 7766,
+      "spell_id": 560568
+    },
+    {
+      "ca_id": 7768,
+      "spell_id": 704149
+    },
+    {
+      "ca_id": 7769,
+      "spell_id": 705655
+    },
+    {
+      "ca_id": 7775,
+      "spell_id": 524620
+    },
+    {
+      "ca_id": 7779,
+      "spell_id": 705936
+    },
+    {
+      "ca_id": 7781,
+      "spell_id": 707650
+    },
+    {
+      "ca_id": 7782,
+      "spell_id": 805196
+    },
+    {
+      "ca_id": 7783,
+      "spell_id": 705426
+    },
+    {
+      "ca_id": 7784,
+      "spell_id": 706788
+    },
+    {
+      "ca_id": 7785,
+      "spell_id": 802988
+    },
+    {
+      "ca_id": 7786,
+      "spell_id": 802290
+    },
+    {
+      "ca_id": 7787,
+      "spell_id": 802039
+    },
+    {
+      "ca_id": 7788,
+      "spell_id": 704317
+    },
+    {
+      "ca_id": 7789,
+      "spell_id": 705028
+    },
+    {
+      "ca_id": 7790,
+      "spell_id": 520369
+    },
+    {
+      "ca_id": 7791,
+      "spell_id": 560959
+    },
+    {
+      "ca_id": 7792,
+      "spell_id": 570014
+    },
+    {
+      "ca_id": 7793,
+      "spell_id": 680931
+    },
+    {
+      "ca_id": 7794,
+      "spell_id": 680469
+    },
+    {
+      "ca_id": 7796,
+      "spell_id": 800181
+    },
+    {
+      "ca_id": 7797,
+      "spell_id": 681119
+    },
+    {
+      "ca_id": 7798,
+      "spell_id": 805867
+    },
+    {
+      "ca_id": 7800,
+      "spell_id": 560145
+    },
+    {
+      "ca_id": 7801,
+      "spell_id": 680453
+    },
+    {
+      "ca_id": 7803,
+      "spell_id": 680970
+    },
+    {
+      "ca_id": 7804,
+      "spell_id": 804617
+    },
+    {
+      "ca_id": 7805,
+      "spell_id": 680419
+    },
+    {
+      "ca_id": 7807,
+      "spell_id": 707627
+    },
+    {
+      "ca_id": 7808,
+      "spell_id": 301304
+    },
+    {
+      "ca_id": 7810,
+      "spell_id": 524913
+    },
+    {
+      "ca_id": 7813,
+      "spell_id": 803163
+    },
+    {
+      "ca_id": 7814,
+      "spell_id": 705274
+    },
+    {
+      "ca_id": 7817,
+      "spell_id": 706894
+    },
+    {
+      "ca_id": 7818,
+      "spell_id": 705634
+    },
+    {
+      "ca_id": 7819,
+      "spell_id": 800807
+    },
+    {
+      "ca_id": 7821,
+      "spell_id": 802164
+    },
+    {
+      "ca_id": 7822,
+      "spell_id": 301253
+    },
+    {
+      "ca_id": 7823,
+      "spell_id": 520608
+    },
+    {
+      "ca_id": 7826,
+      "spell_id": 520045
+    },
+    {
+      "ca_id": 7829,
+      "spell_id": 804060
+    },
+    {
+      "ca_id": 7833,
+      "spell_id": 807505
+    },
+    {
+      "ca_id": 7834,
+      "spell_id": 805727
+    },
+    {
+      "ca_id": 7836,
+      "spell_id": 704540
+    },
+    {
+      "ca_id": 7837,
+      "spell_id": 704209
+    },
+    {
+      "ca_id": 7838,
+      "spell_id": 705704
+    },
+    {
+      "ca_id": 7839,
+      "spell_id": 560995
+    },
+    {
+      "ca_id": 7840,
+      "spell_id": 560593
+    },
+    {
+      "ca_id": 7842,
+      "spell_id": 707256
+    },
+    {
+      "ca_id": 7843,
+      "spell_id": 706150
+    },
+    {
+      "ca_id": 7844,
+      "spell_id": 680936
+    },
+    {
+      "ca_id": 7846,
+      "spell_id": 712429
+    },
+    {
+      "ca_id": 7847,
+      "spell_id": 560939
+    },
+    {
+      "ca_id": 7848,
+      "spell_id": 561360
+    },
+    {
+      "ca_id": 7849,
+      "spell_id": 805726
+    },
+    {
+      "ca_id": 7852,
+      "spell_id": 805767
+    },
+    {
+      "ca_id": 7853,
+      "spell_id": 520166
+    },
+    {
+      "ca_id": 7854,
+      "spell_id": 804438
+    },
+    {
+      "ca_id": 7855,
+      "spell_id": 804436
+    },
+    {
+      "ca_id": 7856,
+      "spell_id": 524853
+    },
+    {
+      "ca_id": 7858,
+      "spell_id": 706297
+    },
+    {
+      "ca_id": 7860,
+      "spell_id": 560641
+    },
+    {
+      "ca_id": 7861,
+      "spell_id": 300478
+    },
+    {
+      "ca_id": 7862,
+      "spell_id": 705109
+    },
+    {
+      "ca_id": 7863,
+      "spell_id": 300467
+    },
+    {
+      "ca_id": 7865,
+      "spell_id": 802058
+    },
+    {
+      "ca_id": 7868,
+      "spell_id": 524947
+    },
+    {
+      "ca_id": 7869,
+      "spell_id": 520252
+    },
+    {
+      "ca_id": 7870,
+      "spell_id": 520592
+    },
+    {
+      "ca_id": 7873,
+      "spell_id": 524945
+    },
+    {
+      "ca_id": 7875,
+      "spell_id": 705467
+    },
+    {
+      "ca_id": 7876,
+      "spell_id": 300969
+    },
+    {
+      "ca_id": 7878,
+      "spell_id": 705792
+    },
+    {
+      "ca_id": 7880,
+      "spell_id": 681026
+    },
+    {
+      "ca_id": 7881,
+      "spell_id": 707388
+    },
+    {
+      "ca_id": 7883,
+      "spell_id": 804947
+    },
+    {
+      "ca_id": 7885,
+      "spell_id": 300385
+    },
+    {
+      "ca_id": 7887,
+      "spell_id": 807587
+    },
+    {
+      "ca_id": 7888,
+      "spell_id": 706501
+    },
+    {
+      "ca_id": 7889,
+      "spell_id": 524920
+    },
+    {
+      "ca_id": 7891,
+      "spell_id": 800710
+    },
+    {
+      "ca_id": 7892,
+      "spell_id": 704952
+    },
+    {
+      "ca_id": 7894,
+      "spell_id": 500751
+    },
+    {
+      "ca_id": 7899,
+      "spell_id": 582589
+    },
+    {
+      "ca_id": 7900,
+      "spell_id": 704897
+    },
+    {
+      "ca_id": 7901,
+      "spell_id": 301209
+    },
+    {
+      "ca_id": 7902,
+      "spell_id": 503806
+    },
+    {
+      "ca_id": 7904,
+      "spell_id": 524870
+    },
+    {
+      "ca_id": 7905,
+      "spell_id": 707380
+    },
+    {
+      "ca_id": 7906,
+      "spell_id": 520353
+    },
+    {
+      "ca_id": 7908,
+      "spell_id": 520581
+    },
+    {
+      "ca_id": 7909,
+      "spell_id": 560547
+    },
+    {
+      "ca_id": 7910,
+      "spell_id": 800054
+    },
+    {
+      "ca_id": 7911,
+      "spell_id": 706085
+    },
+    {
+      "ca_id": 7912,
+      "spell_id": 801271
+    },
+    {
+      "ca_id": 7914,
+      "spell_id": 706133
+    },
+    {
+      "ca_id": 7915,
+      "spell_id": 520457
+    },
+    {
+      "ca_id": 7916,
+      "spell_id": 706128
+    },
+    {
+      "ca_id": 7917,
+      "spell_id": 560949
+    },
+    {
+      "ca_id": 7918,
+      "spell_id": 560791
+    },
+    {
+      "ca_id": 7920,
+      "spell_id": 706046
+    },
+    {
+      "ca_id": 7921,
+      "spell_id": 560789
+    },
+    {
+      "ca_id": 7922,
+      "spell_id": 653239
+    },
+    {
+      "ca_id": 7925,
+      "spell_id": 802107
+    },
+    {
+      "ca_id": 7926,
+      "spell_id": 704816
+    },
+    {
+      "ca_id": 7927,
+      "spell_id": 706886
+    },
+    {
+      "ca_id": 7929,
+      "spell_id": 520372
+    },
+    {
+      "ca_id": 7931,
+      "spell_id": 705559
+    },
+    {
+      "ca_id": 7932,
+      "spell_id": 706875
+    },
+    {
+      "ca_id": 7933,
+      "spell_id": 802780
+    },
+    {
+      "ca_id": 7934,
+      "spell_id": 681334
+    },
+    {
+      "ca_id": 7935,
+      "spell_id": 520402
+    },
+    {
+      "ca_id": 7936,
+      "spell_id": 704818
+    },
+    {
+      "ca_id": 7937,
+      "spell_id": 706076
+    },
+    {
+      "ca_id": 7938,
+      "spell_id": 560977
+    },
+    {
+      "ca_id": 7940,
+      "spell_id": 704881
+    },
+    {
+      "ca_id": 7941,
+      "spell_id": 520405
+    },
+    {
+      "ca_id": 7945,
+      "spell_id": 561099
+    },
+    {
+      "ca_id": 7946,
+      "spell_id": 300560
+    },
+    {
+      "ca_id": 7948,
+      "spell_id": 578295
+    },
+    {
+      "ca_id": 7952,
+      "spell_id": 582855
+    },
+    {
+      "ca_id": 7953,
+      "spell_id": 578320
+    },
+    {
+      "ca_id": 7954,
+      "spell_id": 572582
+    },
+    {
+      "ca_id": 8000,
+      "spell_id": 520466
+    },
+    {
+      "ca_id": 8001,
+      "spell_id": 520469
+    },
+    {
+      "ca_id": 8003,
+      "spell_id": 300772
+    },
+    {
+      "ca_id": 8004,
+      "spell_id": 704783
+    },
+    {
+      "ca_id": 8005,
+      "spell_id": 572530
+    },
+    {
+      "ca_id": 8006,
+      "spell_id": 503717
+    },
+    {
+      "ca_id": 8008,
+      "spell_id": 706338
+    },
+    {
+      "ca_id": 8009,
+      "spell_id": 560810
+    },
+    {
+      "ca_id": 8010,
+      "spell_id": 803113
+    },
+    {
+      "ca_id": 8100,
+      "spell_id": 707588
+    },
+    {
+      "ca_id": 8191,
+      "spell_id": 804599
+    },
+    {
+      "ca_id": 8215,
+      "spell_id": 504627
+    },
+    {
+      "ca_id": 8292,
+      "spell_id": 705436
+    },
+    {
+      "ca_id": 8293,
+      "spell_id": 805717
+    },
+    {
+      "ca_id": 8352,
+      "spell_id": 704649
+    },
+    {
+      "ca_id": 8354,
+      "spell_id": 572367
+    },
+    {
+      "ca_id": 8355,
+      "spell_id": 800347
+    },
+    {
+      "ca_id": 8357,
+      "spell_id": 570735
+    },
+    {
+      "ca_id": 8358,
+      "spell_id": 705076
+    },
+    {
+      "ca_id": 8574,
+      "spell_id": 806289
+    },
+    {
+      "ca_id": 8613,
+      "spell_id": 705666
+    },
+    {
+      "ca_id": 9050,
+      "spell_id": 707618
+    },
+    {
+      "ca_id": 9170,
+      "spell_id": 300505
+    },
+    {
+      "ca_id": 9171,
+      "spell_id": 706481
+    },
+    {
+      "ca_id": 9172,
+      "spell_id": 573256
+    },
+    {
+      "ca_id": 9175,
+      "spell_id": 574308
+    },
+    {
+      "ca_id": 9177,
+      "spell_id": 806292
+    },
+    {
+      "ca_id": 9181,
+      "spell_id": 806290
+    },
+    {
+      "ca_id": 9182,
+      "spell_id": 806301
+    },
+    {
+      "ca_id": 9185,
+      "spell_id": 706114
+    },
+    {
+      "ca_id": 9186,
+      "spell_id": 574312
+    },
+    {
+      "ca_id": 9192,
+      "spell_id": 705242
+    },
+    {
+      "ca_id": 9193,
+      "spell_id": 503718
+    },
+    {
+      "ca_id": 9198,
+      "spell_id": 520923
+    },
+    {
+      "ca_id": 9207,
+      "spell_id": 706159
+    },
+    {
+      "ca_id": 9208,
+      "spell_id": 574323
+    },
+    {
+      "ca_id": 9210,
+      "spell_id": 806718
+    },
+    {
+      "ca_id": 9212,
+      "spell_id": 537218
+    },
+    {
+      "ca_id": 9214,
+      "spell_id": 570183
+    },
+    {
+      "ca_id": 9215,
+      "spell_id": 806583
+    },
+    {
+      "ca_id": 9216,
+      "spell_id": 680406
+    },
+    {
+      "ca_id": 9218,
+      "spell_id": 560503
+    },
+    {
+      "ca_id": 9221,
+      "spell_id": 806698
+    },
+    {
+      "ca_id": 9223,
+      "spell_id": 574138
+    },
+    {
+      "ca_id": 9225,
+      "spell_id": 801235
+    },
+    {
+      "ca_id": 9226,
+      "spell_id": 803645
+    },
+    {
+      "ca_id": 9228,
+      "spell_id": 574140
+    },
+    {
+      "ca_id": 9229,
+      "spell_id": 574143
+    },
+    {
+      "ca_id": 9230,
+      "spell_id": 574145
+    },
+    {
+      "ca_id": 9231,
+      "spell_id": 805246
+    },
+    {
+      "ca_id": 9233,
+      "spell_id": 574146
+    },
+    {
+      "ca_id": 9234,
+      "spell_id": 500580
+    },
+    {
+      "ca_id": 9236,
+      "spell_id": 561022
+    },
+    {
+      "ca_id": 9241,
+      "spell_id": 707638
+    },
+    {
+      "ca_id": 9243,
+      "spell_id": 574348
+    },
+    {
+      "ca_id": 9244,
+      "spell_id": 680233
+    },
+    {
+      "ca_id": 9245,
+      "spell_id": 574349
+    },
+    {
+      "ca_id": 9247,
+      "spell_id": 680748
+    },
+    {
+      "ca_id": 9248,
+      "spell_id": 807659
+    },
+    {
+      "ca_id": 9250,
+      "spell_id": 705725
+    },
+    {
+      "ca_id": 9251,
+      "spell_id": 578299
+    },
+    {
+      "ca_id": 9253,
+      "spell_id": 804827
+    },
+    {
+      "ca_id": 9254,
+      "spell_id": 575030
+    },
+    {
+      "ca_id": 9255,
+      "spell_id": 570057
+    },
+    {
+      "ca_id": 9257,
+      "spell_id": 500551
+    },
+    {
+      "ca_id": 9258,
+      "spell_id": 560546
+    },
+    {
+      "ca_id": 9260,
+      "spell_id": 573035
+    },
+    {
+      "ca_id": 9262,
+      "spell_id": 704951
+    },
+    {
+      "ca_id": 9265,
+      "spell_id": 707548
+    },
+    {
+      "ca_id": 9267,
+      "spell_id": 561170
+    },
+    {
+      "ca_id": 9268,
+      "spell_id": 500542
+    },
+    {
+      "ca_id": 9269,
+      "spell_id": 573039
+    },
+    {
+      "ca_id": 9270,
+      "spell_id": 706576
+    },
+    {
+      "ca_id": 9271,
+      "spell_id": 573041
+    },
+    {
+      "ca_id": 9272,
+      "spell_id": 706784
+    },
+    {
+      "ca_id": 9274,
+      "spell_id": 524831
+    },
+    {
+      "ca_id": 9275,
+      "spell_id": 573044
+    },
+    {
+      "ca_id": 9277,
+      "spell_id": 706483
+    },
+    {
+      "ca_id": 9279,
+      "spell_id": 573047
+    },
+    {
+      "ca_id": 9280,
+      "spell_id": 705970
+    },
+    {
+      "ca_id": 9283,
+      "spell_id": 706211
+    },
+    {
+      "ca_id": 9285,
+      "spell_id": 804342
+    },
+    {
+      "ca_id": 9289,
+      "spell_id": 572547
+    },
+    {
+      "ca_id": 9290,
+      "spell_id": 504107
+    },
+    {
+      "ca_id": 9295,
+      "spell_id": 805607
+    },
+    {
+      "ca_id": 9296,
+      "spell_id": 300286
+    },
+    {
+      "ca_id": 9298,
+      "spell_id": 805121
+    },
+    {
+      "ca_id": 9299,
+      "spell_id": 804286
+    },
+    {
+      "ca_id": 9301,
+      "spell_id": 706182
+    },
+    {
+      "ca_id": 9302,
+      "spell_id": 800463
+    },
+    {
+      "ca_id": 9303,
+      "spell_id": 582310
+    },
+    {
+      "ca_id": 9306,
+      "spell_id": 705456
+    },
+    {
+      "ca_id": 9307,
+      "spell_id": 574148
+    },
+    {
+      "ca_id": 9311,
+      "spell_id": 560280
+    },
+    {
+      "ca_id": 9321,
+      "spell_id": 806146
+    },
+    {
+      "ca_id": 9322,
+      "spell_id": 805718
+    },
+    {
+      "ca_id": 9324,
+      "spell_id": 504322
+    },
+    {
+      "ca_id": 9325,
+      "spell_id": 574354
+    },
+    {
+      "ca_id": 9347,
+      "spell_id": 504459
+    },
+    {
+      "ca_id": 9414,
+      "spell_id": 802273
+    },
+    {
+      "ca_id": 9415,
+      "spell_id": 681092
+    },
+    {
+      "ca_id": 9417,
+      "spell_id": 300572
+    },
+    {
+      "ca_id": 9418,
+      "spell_id": 300978
+    },
+    {
+      "ca_id": 9428,
+      "spell_id": 807748
+    },
+    {
+      "ca_id": 9429,
+      "spell_id": 560785
+    },
+    {
+      "ca_id": 9430,
+      "spell_id": 570338
+    },
+    {
+      "ca_id": 9450,
+      "spell_id": 806142
+    },
+    {
+      "ca_id": 9453,
+      "spell_id": 561190
+    },
+    {
+      "ca_id": 9454,
+      "spell_id": 520925
+    },
+    {
+      "ca_id": 9474,
+      "spell_id": 524979
+    },
+    {
+      "ca_id": 9485,
+      "spell_id": 573034
+    },
+    {
+      "ca_id": 9503,
+      "spell_id": 704449
+    },
+    {
+      "ca_id": 9547,
+      "spell_id": 572527
+    },
+    {
+      "ca_id": 9575,
+      "spell_id": 706370
+    },
+    {
+      "ca_id": 9580,
+      "spell_id": 680497
+    },
+    {
+      "ca_id": 9590,
+      "spell_id": 804963
+    },
+    {
+      "ca_id": 9596,
+      "spell_id": 704941
+    },
+    {
+      "ca_id": 9597,
+      "spell_id": 681047
+    },
+    {
+      "ca_id": 9619,
+      "spell_id": 707463
+    },
+    {
+      "ca_id": 9621,
+      "spell_id": 705815
+    },
+    {
+      "ca_id": 9641,
+      "spell_id": 707055
+    },
+    {
+      "ca_id": 9650,
+      "spell_id": 561159
+    },
+    {
+      "ca_id": 9672,
+      "spell_id": 704193
+    },
+    {
+      "ca_id": 9687,
+      "spell_id": 561208
+    },
+    {
+      "ca_id": 9705,
+      "spell_id": 500124
+    },
+    {
+      "ca_id": 9729,
+      "spell_id": 705560
+    },
+    {
+      "ca_id": 9733,
+      "spell_id": 807558
+    },
+    {
+      "ca_id": 9747,
+      "spell_id": 300339
+    },
+    {
+      "ca_id": 9750,
+      "spell_id": 520062
+    },
+    {
+      "ca_id": 9751,
+      "spell_id": 504645
+    },
+    {
+      "ca_id": 9755,
+      "spell_id": 578302
+    },
+    {
+      "ca_id": 9757,
+      "spell_id": 524739
+    },
+    {
+      "ca_id": 9759,
+      "spell_id": 803236
+    },
+    {
+      "ca_id": 9782,
+      "spell_id": 561106
+    },
+    {
+      "ca_id": 9807,
+      "spell_id": 706858
+    },
+    {
+      "ca_id": 9816,
+      "spell_id": 804339
+    },
+    {
+      "ca_id": 9828,
+      "spell_id": 680975
+    },
+    {
+      "ca_id": 9831,
+      "spell_id": 801328
+    },
+    {
+      "ca_id": 9832,
+      "spell_id": 707444
+    },
+    {
+      "ca_id": 9834,
+      "spell_id": 504628
+    },
+    {
+      "ca_id": 9843,
+      "spell_id": 500302
+    },
+    {
+      "ca_id": 9851,
+      "spell_id": 301280
+    },
+    {
+      "ca_id": 9861,
+      "spell_id": 712673
+    },
+    {
+      "ca_id": 9871,
+      "spell_id": 706239
+    },
+    {
+      "ca_id": 9878,
+      "spell_id": 804340
+    },
+    {
+      "ca_id": 9888,
+      "spell_id": 806525
+    },
+    {
+      "ca_id": 9889,
+      "spell_id": 504006
+    },
+    {
+      "ca_id": 9896,
+      "spell_id": 300361
+    },
+    {
+      "ca_id": 9897,
+      "spell_id": 570336
+    },
+    {
+      "ca_id": 9901,
+      "spell_id": 707072
+    },
+    {
+      "ca_id": 9905,
+      "spell_id": 681078
+    },
+    {
+      "ca_id": 9906,
+      "spell_id": 684331
+    },
+    {
+      "ca_id": 9909,
+      "spell_id": 706340
+    },
+    {
+      "ca_id": 9914,
+      "spell_id": 807404
+    },
+    {
+      "ca_id": 9921,
+      "spell_id": 707451
+    },
+    {
+      "ca_id": 9927,
+      "spell_id": 704831
+    },
+    {
+      "ca_id": 9930,
+      "spell_id": 705650
+    },
+    {
+      "ca_id": 9934,
+      "spell_id": 504439
+    },
+    {
+      "ca_id": 9935,
+      "spell_id": 301315
+    },
+    {
+      "ca_id": 9949,
+      "spell_id": 503913
+    },
+    {
+      "ca_id": 9950,
+      "spell_id": 680725
+    },
+    {
+      "ca_id": 9951,
+      "spell_id": 680800
+    },
+    {
+      "ca_id": 9953,
+      "spell_id": 707429
+    },
+    {
+      "ca_id": 9964,
+      "spell_id": 504733
+    },
+    {
+      "ca_id": 9967,
+      "spell_id": 500567
+    },
+    {
+      "ca_id": 9970,
+      "spell_id": 706617
+    },
+    {
+      "ca_id": 9975,
+      "spell_id": 705579
+    },
+    {
+      "ca_id": 9977,
+      "spell_id": 807343
+    },
+    {
+      "ca_id": 9980,
+      "spell_id": 807388
+    },
+    {
+      "ca_id": 9986,
+      "spell_id": 555737
+    },
+    {
+      "ca_id": 9987,
+      "spell_id": 706904
+    },
+    {
+      "ca_id": 9995,
+      "spell_id": 506819
+    },
+    {
+      "ca_id": 9999,
+      "spell_id": 560167
+    },
+    {
+      "ca_id": 10054,
+      "spell_id": 520492
+    },
+    {
+      "ca_id": 10363,
+      "spell_id": 712678
+    },
+    {
+      "ca_id": 10495,
+      "spell_id": 805032
+    },
+    {
+      "ca_id": 10543,
+      "spell_id": 712683
+    },
+    {
+      "ca_id": 10571,
+      "spell_id": 301322
+    },
+    {
+      "ca_id": 10728,
+      "spell_id": 807691
+    },
+    {
+      "ca_id": 10755,
+      "spell_id": 301260
+    },
+    {
+      "ca_id": 10836,
+      "spell_id": 505202
+    },
+    {
+      "ca_id": 10909,
+      "spell_id": 807461
+    },
+    {
+      "ca_id": 10913,
+      "spell_id": 680397
+    },
+    {
+      "ca_id": 10918,
+      "spell_id": 300235
+    },
+    {
+      "ca_id": 10922,
+      "spell_id": 707657
+    },
+    {
+      "ca_id": 10956,
+      "spell_id": 681436
+    },
+    {
+      "ca_id": 10983,
+      "spell_id": 680508
+    },
+    {
+      "ca_id": 11006,
+      "spell_id": 707629
+    },
+    {
+      "ca_id": 11013,
+      "spell_id": 504786
+    },
+    {
+      "ca_id": 11025,
+      "spell_id": 707528
+    },
+    {
+      "ca_id": 11040,
+      "spell_id": 504782
+    },
+    {
+      "ca_id": 11051,
+      "spell_id": 707433
+    },
+    {
+      "ca_id": 11060,
+      "spell_id": 803571
+    },
+    {
+      "ca_id": 11106,
+      "spell_id": 704961
+    },
+    {
+      "ca_id": 11111,
+      "spell_id": 705131
+    },
+    {
+      "ca_id": 11112,
+      "spell_id": 704718
+    },
+    {
+      "ca_id": 11120,
+      "spell_id": 707271
+    },
+    {
+      "ca_id": 11121,
+      "spell_id": 520831
+    },
+    {
+      "ca_id": 11122,
+      "spell_id": 707656
+    },
+    {
+      "ca_id": 11133,
+      "spell_id": 704500
+    },
+    {
+      "ca_id": 11134,
+      "spell_id": 807467
+    },
+    {
+      "ca_id": 11140,
+      "spell_id": 520131
+    },
+    {
+      "ca_id": 11145,
+      "spell_id": 707479
+    },
+    {
+      "ca_id": 11151,
+      "spell_id": 561228
+    },
+    {
+      "ca_id": 11153,
+      "spell_id": 807560
+    },
+    {
+      "ca_id": 11154,
+      "spell_id": 504774
+    },
+    {
+      "ca_id": 11163,
+      "spell_id": 805442
+    },
+    {
+      "ca_id": 11164,
+      "spell_id": 807450
+    },
+    {
+      "ca_id": 11167,
+      "spell_id": 807023
+    },
+    {
+      "ca_id": 11168,
+      "spell_id": 561394
+    },
+    {
+      "ca_id": 11170,
+      "spell_id": 807578
+    },
+    {
+      "ca_id": 11171,
+      "spell_id": 707648
+    },
+    {
+      "ca_id": 11172,
+      "spell_id": 803511
+    },
+    {
+      "ca_id": 11175,
+      "spell_id": 582356
+    },
+    {
+      "ca_id": 11176,
+      "spell_id": 807569
+    },
+    {
+      "ca_id": 11177,
+      "spell_id": 707504
+    },
+    {
+      "ca_id": 11184,
+      "spell_id": 707514
+    },
+    {
+      "ca_id": 11185,
+      "spell_id": 570207
+    },
+    {
+      "ca_id": 11193,
+      "spell_id": 300730
+    },
+    {
+      "ca_id": 11196,
+      "spell_id": 681363
+    },
+    {
+      "ca_id": 11197,
+      "spell_id": 680537
+    },
+    {
+      "ca_id": 11206,
+      "spell_id": 680684
+    },
+    {
+      "ca_id": 11207,
+      "spell_id": 706633
+    },
+    {
+      "ca_id": 11210,
+      "spell_id": 707513
+    },
+    {
+      "ca_id": 11212,
+      "spell_id": 704953
+    },
+    {
+      "ca_id": 11213,
+      "spell_id": 807431
+    },
+    {
+      "ca_id": 11214,
+      "spell_id": 505228
+    },
+    {
+      "ca_id": 11215,
+      "spell_id": 500219
+    },
+    {
+      "ca_id": 11217,
+      "spell_id": 807438
+    },
+    {
+      "ca_id": 11218,
+      "spell_id": 802011
+    },
+    {
+      "ca_id": 11219,
+      "spell_id": 803798
+    },
+    {
+      "ca_id": 11224,
+      "spell_id": 802108
+    },
+    {
+      "ca_id": 11227,
+      "spell_id": 807430
+    },
+    {
+      "ca_id": 11228,
+      "spell_id": 574153
+    },
+    {
+      "ca_id": 11233,
+      "spell_id": 500067
+    },
+    {
+      "ca_id": 11235,
+      "spell_id": 806124
+    },
+    {
+      "ca_id": 11236,
+      "spell_id": 707560
+    },
+    {
+      "ca_id": 11237,
+      "spell_id": 704632
+    },
+    {
+      "ca_id": 11243,
+      "spell_id": 805443
+    },
+    {
+      "ca_id": 11251,
+      "spell_id": 807566
+    },
+    {
+      "ca_id": 11252,
+      "spell_id": 578300
+    },
+    {
+      "ca_id": 11253,
+      "spell_id": 300619
+    },
+    {
+      "ca_id": 11255,
+      "spell_id": 805888
+    },
+    {
+      "ca_id": 11256,
+      "spell_id": 500004
+    },
+    {
+      "ca_id": 11257,
+      "spell_id": 707541
+    },
+    {
+      "ca_id": 11261,
+      "spell_id": 706331
+    },
+    {
+      "ca_id": 11262,
+      "spell_id": 807415
+    },
+    {
+      "ca_id": 11268,
+      "spell_id": 500584
+    },
+    {
+      "ca_id": 11273,
+      "spell_id": 807589
+    },
+    {
+      "ca_id": 11287,
+      "spell_id": 301310
+    },
+    {
+      "ca_id": 11288,
+      "spell_id": 705281
+    },
+    {
+      "ca_id": 11290,
+      "spell_id": 804932
+    },
+    {
+      "ca_id": 11292,
+      "spell_id": 520833
+    },
+    {
+      "ca_id": 11294,
+      "spell_id": 706468
+    },
+    {
+      "ca_id": 11295,
+      "spell_id": 804927
+    },
+    {
+      "ca_id": 11297,
+      "spell_id": 574318
+    },
+    {
+      "ca_id": 11298,
+      "spell_id": 681107
+    },
+    {
+      "ca_id": 11302,
+      "spell_id": 707583
+    },
+    {
+      "ca_id": 11304,
+      "spell_id": 704801
+    },
+    {
+      "ca_id": 11309,
+      "spell_id": 805587
+    },
+    {
+      "ca_id": 11323,
+      "spell_id": 301297
+    },
+    {
+      "ca_id": 11324,
+      "spell_id": 561196
+    },
+    {
+      "ca_id": 11330,
+      "spell_id": 712435
+    },
+    {
+      "ca_id": 11334,
+      "spell_id": 574326
+    },
+    {
+      "ca_id": 11336,
+      "spell_id": 705068
+    },
+    {
+      "ca_id": 11349,
+      "spell_id": 704311
+    },
+    {
+      "ca_id": 11360,
+      "spell_id": 805828
+    },
+    {
+      "ca_id": 11375,
+      "spell_id": 705520
+    },
+    {
+      "ca_id": 11380,
+      "spell_id": 707613
+    },
+    {
+      "ca_id": 11384,
+      "spell_id": 707606
+    },
+    {
+      "ca_id": 11393,
+      "spell_id": 561210
+    },
+    {
+      "ca_id": 11418,
+      "spell_id": 561193
+    },
+    {
+      "ca_id": 11419,
+      "spell_id": 807788
+    },
+    {
+      "ca_id": 11431,
+      "spell_id": 532261
+    },
+    {
+      "ca_id": 11435,
+      "spell_id": 560567
+    },
+    {
+      "ca_id": 11436,
+      "spell_id": 520083
+    },
+    {
+      "ca_id": 11437,
+      "spell_id": 520834
+    },
+    {
+      "ca_id": 11438,
+      "spell_id": 704681
+    },
+    {
+      "ca_id": 11444,
+      "spell_id": 707622
+    },
+    {
+      "ca_id": 11451,
+      "spell_id": 707493
+    },
+    {
+      "ca_id": 11455,
+      "spell_id": 504808
+    },
+    {
+      "ca_id": 11468,
+      "spell_id": 807657
+    },
+    {
+      "ca_id": 11472,
+      "spell_id": 806206
+    },
+    {
+      "ca_id": 11528,
+      "spell_id": 805591
+    },
+    {
+      "ca_id": 11532,
+      "spell_id": 807296
+    },
+    {
+      "ca_id": 11584,
+      "spell_id": 707546
+    },
+    {
+      "ca_id": 11605,
+      "spell_id": 707654
+    },
+    {
+      "ca_id": 11619,
+      "spell_id": 531130
+    },
+    {
+      "ca_id": 11623,
+      "spell_id": 807700
+    },
+    {
+      "ca_id": 11627,
+      "spell_id": 561195
+    },
+    {
+      "ca_id": 11636,
+      "spell_id": 302914
+    },
+    {
+      "ca_id": 11647,
+      "spell_id": 707653
+    },
+    {
+      "ca_id": 11648,
+      "spell_id": 301295
+    },
+    {
+      "ca_id": 11651,
+      "spell_id": 704935
+    },
+    {
+      "ca_id": 11660,
+      "spell_id": 801145
+    },
+    {
+      "ca_id": 11661,
+      "spell_id": 681444
+    },
+    {
+      "ca_id": 11685,
+      "spell_id": 504602
+    },
+    {
+      "ca_id": 11735,
+      "spell_id": 707574
+    },
+    {
+      "ca_id": 11788,
+      "spell_id": 520153
+    },
+    {
+      "ca_id": 11797,
+      "spell_id": 803683
+    },
+    {
+      "ca_id": 11803,
+      "spell_id": 704815
+    },
+    {
+      "ca_id": 11804,
+      "spell_id": 807610
+    },
+    {
+      "ca_id": 11811,
+      "spell_id": 706232
+    },
+    {
+      "ca_id": 11814,
+      "spell_id": 300485
+    },
+    {
+      "ca_id": 11836,
+      "spell_id": 705352
+    },
+    {
+      "ca_id": 11837,
+      "spell_id": 520835
+    },
+    {
+      "ca_id": 11857,
+      "spell_id": 712431
+    },
+    {
+      "ca_id": 11861,
+      "spell_id": 704490
+    },
+    {
+      "ca_id": 11874,
+      "spell_id": 707503
+    },
+    {
+      "ca_id": 11880,
+      "spell_id": 301181
+    },
+    {
+      "ca_id": 11882,
+      "spell_id": 504754
+    },
+    {
+      "ca_id": 11890,
+      "spell_id": 707631
+    },
+    {
+      "ca_id": 11892,
+      "spell_id": 525049
+    },
+    {
+      "ca_id": 11904,
+      "spell_id": 560727
+    },
+    {
+      "ca_id": 11906,
+      "spell_id": 520314
+    },
+    {
+      "ca_id": 11910,
+      "spell_id": 560113
+    },
+    {
+      "ca_id": 11911,
+      "spell_id": 561204
+    },
+    {
+      "ca_id": 11914,
+      "spell_id": 561201
+    },
+    {
+      "ca_id": 11916,
+      "spell_id": 680679
+    },
+    {
+      "ca_id": 11926,
+      "spell_id": 707652
+    },
+    {
+      "ca_id": 11930,
+      "spell_id": 705094
+    },
+    {
+      "ca_id": 11935,
+      "spell_id": 707753
+    },
+    {
+      "ca_id": 11936,
+      "spell_id": 707494
+    },
+    {
+      "ca_id": 11940,
+      "spell_id": 500069
+    },
+    {
+      "ca_id": 11949,
+      "spell_id": 301318
+    },
+    {
+      "ca_id": 11955,
+      "spell_id": 573059
+    },
+    {
+      "ca_id": 11956,
+      "spell_id": 705070
+    },
+    {
+      "ca_id": 11963,
+      "spell_id": 706896
+    },
+    {
+      "ca_id": 11964,
+      "spell_id": 801905
+    },
+    {
+      "ca_id": 11982,
+      "spell_id": 707414
+    },
+    {
+      "ca_id": 11986,
+      "spell_id": 301286
+    },
+    {
+      "ca_id": 12048,
+      "spell_id": 572870
+    },
+    {
+      "ca_id": 12086,
+      "spell_id": 707854
+    },
+    {
+      "ca_id": 12112,
+      "spell_id": 804737
+    },
+    {
+      "ca_id": 12123,
+      "spell_id": 704526
+    },
+    {
+      "ca_id": 12126,
+      "spell_id": 704756
+    },
+    {
+      "ca_id": 12142,
+      "spell_id": 681330
+    },
+    {
+      "ca_id": 12145,
+      "spell_id": 503712
+    },
+    {
+      "ca_id": 12153,
+      "spell_id": 805815
+    },
+    {
+      "ca_id": 12165,
+      "spell_id": 706472
+    },
+    {
+      "ca_id": 12166,
+      "spell_id": 570727
+    },
+    {
+      "ca_id": 12170,
+      "spell_id": 520853
+    },
+    {
+      "ca_id": 12179,
+      "spell_id": 807671
+    },
+    {
+      "ca_id": 12184,
+      "spell_id": 807754
+    },
+    {
+      "ca_id": 12201,
+      "spell_id": 804961
+    },
+    {
+      "ca_id": 12208,
+      "spell_id": 300729
+    },
+    {
+      "ca_id": 12210,
+      "spell_id": 806458
+    },
+    {
+      "ca_id": 12212,
+      "spell_id": 504489
+    },
+    {
+      "ca_id": 12215,
+      "spell_id": 520854
+    },
+    {
+      "ca_id": 12219,
+      "spell_id": 806175
+    },
+    {
+      "ca_id": 12223,
+      "spell_id": 805884
+    },
+    {
+      "ca_id": 12224,
+      "spell_id": 707633
+    },
+    {
+      "ca_id": 12253,
+      "spell_id": 681407
+    },
+    {
+      "ca_id": 12259,
+      "spell_id": 681453
+    },
+    {
+      "ca_id": 12261,
+      "spell_id": 681473
+    },
+    {
+      "ca_id": 12263,
+      "spell_id": 802006
+    },
+    {
+      "ca_id": 12264,
+      "spell_id": 503748
+    },
+    {
+      "ca_id": 12269,
+      "spell_id": 705437
+    },
+    {
+      "ca_id": 12277,
+      "spell_id": 807863
+    },
+    {
+      "ca_id": 12279,
+      "spell_id": 520875
+    },
+    {
+      "ca_id": 12293,
+      "spell_id": 705303
+    },
+    {
+      "ca_id": 12295,
+      "spell_id": 300529
+    },
+    {
+      "ca_id": 12303,
+      "spell_id": 520851
+    },
+    {
+      "ca_id": 12304,
+      "spell_id": 563736
+    },
+    {
+      "ca_id": 12317,
+      "spell_id": 804040
+    },
+    {
+      "ca_id": 12325,
+      "spell_id": 805931
+    },
+    {
+      "ca_id": 12330,
+      "spell_id": 706793
+    },
+    {
+      "ca_id": 12351,
+      "spell_id": 807963
+    },
+    {
+      "ca_id": 12357,
+      "spell_id": 570758
+    },
+    {
+      "ca_id": 12360,
+      "spell_id": 681478
+    },
+    {
+      "ca_id": 12361,
+      "spell_id": 301339
+    },
+    {
+      "ca_id": 12379,
+      "spell_id": 707623
+    },
+    {
+      "ca_id": 12381,
+      "spell_id": 707739
+    },
+    {
+      "ca_id": 12430,
+      "spell_id": 504874
+    },
+    {
+      "ca_id": 12431,
+      "spell_id": 504151
+    },
+    {
+      "ca_id": 12444,
+      "spell_id": 707747
+    },
+    {
+      "ca_id": 12448,
+      "spell_id": 570023
+    },
+    {
+      "ca_id": 12449,
+      "spell_id": 807626
+    },
+    {
+      "ca_id": 12453,
+      "spell_id": 806384
+    },
+    {
+      "ca_id": 12463,
+      "spell_id": 804728
+    },
+    {
+      "ca_id": 12485,
+      "spell_id": 504837
+    },
+    {
+      "ca_id": 12525,
+      "spell_id": 807855
+    },
+    {
+      "ca_id": 12532,
+      "spell_id": 801821
+    },
+    {
+      "ca_id": 12543,
+      "spell_id": 707810
+    },
+    {
+      "ca_id": 12546,
+      "spell_id": 681411
+    },
+    {
+      "ca_id": 12551,
+      "spell_id": 525048
+    },
+    {
+      "ca_id": 12562,
+      "spell_id": 802047
+    },
+    {
+      "ca_id": 12563,
+      "spell_id": 560532
+    },
+    {
+      "ca_id": 12567,
+      "spell_id": 706171
+    },
+    {
+      "ca_id": 12607,
+      "spell_id": 500578
+    },
+    {
+      "ca_id": 12620,
+      "spell_id": 707835
+    },
+    {
+      "ca_id": 12639,
+      "spell_id": 681448
+    },
+    {
+      "ca_id": 12645,
+      "spell_id": 801660
+    },
+    {
+      "ca_id": 12646,
+      "spell_id": 801661
+    },
+    {
+      "ca_id": 12684,
+      "spell_id": 704789
+    },
+    {
+      "ca_id": 12710,
+      "spell_id": 707621
+    },
+    {
+      "ca_id": 12737,
+      "spell_id": 560441
+    },
+    {
+      "ca_id": 12739,
+      "spell_id": 707762
+    },
+    {
+      "ca_id": 12749,
+      "spell_id": 681465
+    },
+    {
+      "ca_id": 12765,
+      "spell_id": 573066
+    },
+    {
+      "ca_id": 12770,
+      "spell_id": 561321
+    },
+    {
+      "ca_id": 12817,
+      "spell_id": 707632
+    },
+    {
+      "ca_id": 12832,
+      "spell_id": 804253
+    },
+    {
+      "ca_id": 12843,
+      "spell_id": 573038
+    },
+    {
+      "ca_id": 12852,
+      "spell_id": 806188
+    },
+    {
+      "ca_id": 12853,
+      "spell_id": 804478
+    },
+    {
+      "ca_id": 12891,
+      "spell_id": 803797
+    },
+    {
+      "ca_id": 12896,
+      "spell_id": 561227
+    },
+    {
+      "ca_id": 12906,
+      "spell_id": 685028
+    },
+    {
+      "ca_id": 12919,
+      "spell_id": 570722
+    },
+    {
+      "ca_id": 12938,
+      "spell_id": 561320
+    },
+    {
+      "ca_id": 12975,
+      "spell_id": 806382
+    },
+    {
+      "ca_id": 12982,
+      "spell_id": 800402
+    },
+    {
+      "ca_id": 13029,
+      "spell_id": 707619
+    },
+    {
+      "ca_id": 13052,
+      "spell_id": 301317
+    },
+    {
+      "ca_id": 13111,
+      "spell_id": 804456
+    },
+    {
+      "ca_id": 13133,
+      "spell_id": 706369
+    },
+    {
+      "ca_id": 13164,
+      "spell_id": 707885
+    },
+    {
+      "ca_id": 13168,
+      "spell_id": 561314
+    },
+    {
+      "ca_id": 13216,
+      "spell_id": 707616
+    },
+    {
+      "ca_id": 13243,
+      "spell_id": 707751
+    },
+    {
+      "ca_id": 13248,
+      "spell_id": 574351
+    },
+    {
+      "ca_id": 13435,
+      "spell_id": 681427
+    },
+    {
+      "ca_id": 13472,
+      "spell_id": 807243
+    },
+    {
+      "ca_id": 13500,
+      "spell_id": 561342
+    },
+    {
+      "ca_id": 13505,
+      "spell_id": 707620
+    },
+    {
+      "ca_id": 13527,
+      "spell_id": 681435
+    },
+    {
+      "ca_id": 13572,
+      "spell_id": 805808
+    },
+    {
+      "ca_id": 13576,
+      "spell_id": 800401
+    },
+    {
+      "ca_id": 13616,
+      "spell_id": 504159
+    },
+    {
+      "ca_id": 13684,
+      "spell_id": 707626
+    },
+    {
+      "ca_id": 13706,
+      "spell_id": 707624
+    },
+    {
+      "ca_id": 13783,
+      "spell_id": 504798
+    },
+    {
+      "ca_id": 13784,
+      "spell_id": 707634
+    },
+    {
+      "ca_id": 13801,
+      "spell_id": 500205
+    },
+    {
+      "ca_id": 13828,
+      "spell_id": 300989
+    },
+    {
+      "ca_id": 13852,
+      "spell_id": 807741
+    },
+    {
+      "ca_id": 13897,
+      "spell_id": 681326
+    },
+    {
+      "ca_id": 13958,
+      "spell_id": 803817
+    },
+    {
+      "ca_id": 14001,
+      "spell_id": 707517
+    },
+    {
+      "ca_id": 14154,
+      "spell_id": 705613
+    },
+    {
+      "ca_id": 14171,
+      "spell_id": 561160
+    },
+    {
+      "ca_id": 14234,
+      "spell_id": 301306
+    },
+    {
+      "ca_id": 14237,
+      "spell_id": 570242
+    },
+    {
+      "ca_id": 14241,
+      "spell_id": 807686
+    },
+    {
+      "ca_id": 14277,
+      "spell_id": 560452
+    },
+    {
+      "ca_id": 14303,
+      "spell_id": 800193
+    },
+    {
+      "ca_id": 14304,
+      "spell_id": 807861
+    },
+    {
+      "ca_id": 17414,
+      "spell_id": 801343
+    },
+    {
+      "ca_id": 19106,
+      "spell_id": 805093
+    },
+    {
+      "ca_id": 19192,
+      "spell_id": 574321
+    },
+    {
+      "ca_id": 19218,
+      "spell_id": 582937
+    },
+    {
+      "ca_id": 19222,
+      "spell_id": 704163
+    },
+    {
+      "ca_id": 19451,
+      "spell_id": 707663
+    },
+    {
+      "ca_id": 19511,
+      "spell_id": 561328
+    },
+    {
+      "ca_id": 19631,
+      "spell_id": 804712
+    },
+    {
+      "ca_id": 19684,
+      "spell_id": 572310
+    },
+    {
+      "ca_id": 19699,
+      "spell_id": 805433
+    },
+    {
+      "ca_id": 19778,
+      "spell_id": 707562
+    },
+    {
+      "ca_id": 19886,
+      "spell_id": 707637
+    },
+    {
+      "ca_id": 19978,
+      "spell_id": 806299
+    },
+    {
+      "ca_id": 19979,
+      "spell_id": 560383
+    },
+    {
+      "ca_id": 19980,
+      "spell_id": 572352
+    },
+    {
+      "ca_id": 29121,
+      "spell_id": 803678
+    },
+    {
+      "ca_id": 29132,
+      "spell_id": 804610
+    },
+    {
+      "ca_id": 29137,
+      "spell_id": 500039
+    },
+    {
+      "ca_id": 29138,
+      "spell_id": 500041
+    },
+    {
+      "ca_id": 29139,
+      "spell_id": 806307
+    },
+    {
+      "ca_id": 29141,
+      "spell_id": 705663
+    },
+    {
+      "ca_id": 29144,
+      "spell_id": 804725
+    },
+    {
+      "ca_id": 29148,
+      "spell_id": 524867
+    },
+    {
+      "ca_id": 29150,
+      "spell_id": 500085
+    },
+    {
+      "ca_id": 29156,
+      "spell_id": 680326
+    },
+    {
+      "ca_id": 29159,
+      "spell_id": 705450
+    },
+    {
+      "ca_id": 29161,
+      "spell_id": 300789
+    },
+    {
+      "ca_id": 29162,
+      "spell_id": 804190
+    },
+    {
+      "ca_id": 29163,
+      "spell_id": 139778
+    },
+    {
+      "ca_id": 29166,
+      "spell_id": 705562
+    },
+    {
+      "ca_id": 29167,
+      "spell_id": 500121
+    },
+    {
+      "ca_id": 29173,
+      "spell_id": 804207
+    },
+    {
+      "ca_id": 29178,
+      "spell_id": 704945
+    },
+    {
+      "ca_id": 29181,
+      "spell_id": 800600
+    },
+    {
+      "ca_id": 29182,
+      "spell_id": 300324
+    },
+    {
+      "ca_id": 29183,
+      "spell_id": 706735
+    },
+    {
+      "ca_id": 29189,
+      "spell_id": 800796
+    },
+    {
+      "ca_id": 29195,
+      "spell_id": 704642
+    },
+    {
+      "ca_id": 29196,
+      "spell_id": 705752
+    },
+    {
+      "ca_id": 29201,
+      "spell_id": 572538
+    },
+    {
+      "ca_id": 29203,
+      "spell_id": 804673
+    },
+    {
+      "ca_id": 29206,
+      "spell_id": 500242
+    },
+    {
+      "ca_id": 29209,
+      "spell_id": 801706
+    },
+    {
+      "ca_id": 29213,
+      "spell_id": 705346
+    },
+    {
+      "ca_id": 29214,
+      "spell_id": 500259
+    },
+    {
+      "ca_id": 29216,
+      "spell_id": 500261
+    },
+    {
+      "ca_id": 29218,
+      "spell_id": 500287
+    },
+    {
+      "ca_id": 29219,
+      "spell_id": 582933
+    },
+    {
+      "ca_id": 29220,
+      "spell_id": 503837
+    },
+    {
+      "ca_id": 29221,
+      "spell_id": 567233
+    },
+    {
+      "ca_id": 29222,
+      "spell_id": 300584
+    },
+    {
+      "ca_id": 29226,
+      "spell_id": 806797
+    },
+    {
+      "ca_id": 29228,
+      "spell_id": 500296
+    },
+    {
+      "ca_id": 29230,
+      "spell_id": 805462
+    },
+    {
+      "ca_id": 29231,
+      "spell_id": 681281
+    },
+    {
+      "ca_id": 29233,
+      "spell_id": 555723
+    },
+    {
+      "ca_id": 29241,
+      "spell_id": 500572
+    },
+    {
+      "ca_id": 29242,
+      "spell_id": 707001
+    },
+    {
+      "ca_id": 29244,
+      "spell_id": 680388
+    },
+    {
+      "ca_id": 29246,
+      "spell_id": 805204
+    },
+    {
+      "ca_id": 29247,
+      "spell_id": 707305
+    },
+    {
+      "ca_id": 29248,
+      "spell_id": 500359
+    },
+    {
+      "ca_id": 29249,
+      "spell_id": 500484
+    },
+    {
+      "ca_id": 29250,
+      "spell_id": 705428
+    },
+    {
+      "ca_id": 29252,
+      "spell_id": 500692
+    },
+    {
+      "ca_id": 29255,
+      "spell_id": 501562
+    },
+    {
+      "ca_id": 29258,
+      "spell_id": 680476
+    },
+    {
+      "ca_id": 29259,
+      "spell_id": 801481
+    },
+    {
+      "ca_id": 29263,
+      "spell_id": 704887
+    },
+    {
+      "ca_id": 29265,
+      "spell_id": 500715
+    },
+    {
+      "ca_id": 29266,
+      "spell_id": 301068
+    },
+    {
+      "ca_id": 29267,
+      "spell_id": 802049
+    },
+    {
+      "ca_id": 29268,
+      "spell_id": 706928
+    },
+    {
+      "ca_id": 29270,
+      "spell_id": 704527
+    },
+    {
+      "ca_id": 29272,
+      "spell_id": 805115
+    },
+    {
+      "ca_id": 29273,
+      "spell_id": 680600
+    },
+    {
+      "ca_id": 29275,
+      "spell_id": 520388
+    },
+    {
+      "ca_id": 29277,
+      "spell_id": 520548
+    },
+    {
+      "ca_id": 29280,
+      "spell_id": 705008
+    },
+    {
+      "ca_id": 29281,
+      "spell_id": 850021
+    },
+    {
+      "ca_id": 29284,
+      "spell_id": 805780
+    },
+    {
+      "ca_id": 29290,
+      "spell_id": 500928
+    },
+    {
+      "ca_id": 29296,
+      "spell_id": 301087
+    },
+    {
+      "ca_id": 29299,
+      "spell_id": 806415
+    },
+    {
+      "ca_id": 29301,
+      "spell_id": 707162
+    },
+    {
+      "ca_id": 29303,
+      "spell_id": 561072
+    },
+    {
+      "ca_id": 29306,
+      "spell_id": 500947
+    },
+    {
+      "ca_id": 29309,
+      "spell_id": 504840
+    },
+    {
+      "ca_id": 29310,
+      "spell_id": 705870
+    },
+    {
+      "ca_id": 29317,
+      "spell_id": 572023
+    },
+    {
+      "ca_id": 29322,
+      "spell_id": 801759
+    },
+    {
+      "ca_id": 29323,
+      "spell_id": 704929
+    },
+    {
+      "ca_id": 29328,
+      "spell_id": 806957
+    },
+    {
+      "ca_id": 29329,
+      "spell_id": 704986
+    },
+    {
+      "ca_id": 29331,
+      "spell_id": 800084
+    },
+    {
+      "ca_id": 29337,
+      "spell_id": 801435
+    },
+    {
+      "ca_id": 29339,
+      "spell_id": 560286
+    },
+    {
+      "ca_id": 29340,
+      "spell_id": 707244
+    },
+    {
+      "ca_id": 29341,
+      "spell_id": 804833
+    },
+    {
+      "ca_id": 29343,
+      "spell_id": 704139
+    },
+    {
+      "ca_id": 29344,
+      "spell_id": 520345
+    },
+    {
+      "ca_id": 29346,
+      "spell_id": 520156
+    },
+    {
+      "ca_id": 29348,
+      "spell_id": 805811
+    },
+    {
+      "ca_id": 29349,
+      "spell_id": 300698
+    },
+    {
+      "ca_id": 29350,
+      "spell_id": 800180
+    },
+    {
+      "ca_id": 29357,
+      "spell_id": 504197
+    },
+    {
+      "ca_id": 29362,
+      "spell_id": 800094
+    },
+    {
+      "ca_id": 29363,
+      "spell_id": 800144
+    },
+    {
+      "ca_id": 29364,
+      "spell_id": 500335
+    },
+    {
+      "ca_id": 29366,
+      "spell_id": 805804
+    },
+    {
+      "ca_id": 29367,
+      "spell_id": 805248
+    },
+    {
+      "ca_id": 29370,
+      "spell_id": 300226
+    },
+    {
+      "ca_id": 29371,
+      "spell_id": 524970
+    },
+    {
+      "ca_id": 29372,
+      "spell_id": 805754
+    },
+    {
+      "ca_id": 29373,
+      "spell_id": 680323
+    },
+    {
+      "ca_id": 29376,
+      "spell_id": 680199
+    },
+    {
+      "ca_id": 29378,
+      "spell_id": 800172
+    },
+    {
+      "ca_id": 29379,
+      "spell_id": 560487
+    },
+    {
+      "ca_id": 29382,
+      "spell_id": 800178
+    },
+    {
+      "ca_id": 29383,
+      "spell_id": 504222
+    },
+    {
+      "ca_id": 29385,
+      "spell_id": 800184
+    },
+    {
+      "ca_id": 29387,
+      "spell_id": 801903
+    },
+    {
+      "ca_id": 29396,
+      "spell_id": 800204
+    },
+    {
+      "ca_id": 29398,
+      "spell_id": 520817
+    },
+    {
+      "ca_id": 29399,
+      "spell_id": 805244
+    },
+    {
+      "ca_id": 29402,
+      "spell_id": 570077
+    },
+    {
+      "ca_id": 29405,
+      "spell_id": 802076
+    },
+    {
+      "ca_id": 29407,
+      "spell_id": 800220
+    },
+    {
+      "ca_id": 29409,
+      "spell_id": 300468
+    },
+    {
+      "ca_id": 29410,
+      "spell_id": 705677
+    },
+    {
+      "ca_id": 29413,
+      "spell_id": 534267
+    },
+    {
+      "ca_id": 29416,
+      "spell_id": 705092
+    },
+    {
+      "ca_id": 29426,
+      "spell_id": 504730
+    },
+    {
+      "ca_id": 29427,
+      "spell_id": 804892
+    },
+    {
+      "ca_id": 29429,
+      "spell_id": 806134
+    },
+    {
+      "ca_id": 29430,
+      "spell_id": 802304
+    },
+    {
+      "ca_id": 29431,
+      "spell_id": 802188
+    },
+    {
+      "ca_id": 29432,
+      "spell_id": 704539
+    },
+    {
+      "ca_id": 29433,
+      "spell_id": 705320
+    },
+    {
+      "ca_id": 29437,
+      "spell_id": 300382
+    },
+    {
+      "ca_id": 29440,
+      "spell_id": 801744
+    },
+    {
+      "ca_id": 29441,
+      "spell_id": 573247
+    },
+    {
+      "ca_id": 29442,
+      "spell_id": 800210
+    },
+    {
+      "ca_id": 29445,
+      "spell_id": 800355
+    },
+    {
+      "ca_id": 29446,
+      "spell_id": 806159
+    },
+    {
+      "ca_id": 29447,
+      "spell_id": 300700
+    },
+    {
+      "ca_id": 29449,
+      "spell_id": 804939
+    },
+    {
+      "ca_id": 29452,
+      "spell_id": 504003
+    },
+    {
+      "ca_id": 29453,
+      "spell_id": 712471
+    },
+    {
+      "ca_id": 29455,
+      "spell_id": 805126
+    },
+    {
+      "ca_id": 29462,
+      "spell_id": 704741
+    },
+    {
+      "ca_id": 29467,
+      "spell_id": 300249
+    },
+    {
+      "ca_id": 29468,
+      "spell_id": 805864
+    },
+    {
+      "ca_id": 29470,
+      "spell_id": 560109
+    },
+    {
+      "ca_id": 29471,
+      "spell_id": 802727
+    },
+    {
+      "ca_id": 29473,
+      "spell_id": 705307
+    },
+    {
+      "ca_id": 29476,
+      "spell_id": 301200
+    },
+    {
+      "ca_id": 29477,
+      "spell_id": 706909
+    },
+    {
+      "ca_id": 29478,
+      "spell_id": 300307
+    },
+    {
+      "ca_id": 29479,
+      "spell_id": 301241
+    },
+    {
+      "ca_id": 29484,
+      "spell_id": 804199
+    },
+    {
+      "ca_id": 29485,
+      "spell_id": 504710
+    },
+    {
+      "ca_id": 29488,
+      "spell_id": 800497
+    },
+    {
+      "ca_id": 29489,
+      "spell_id": 300252
+    },
+    {
+      "ca_id": 29490,
+      "spell_id": 801989
+    },
+    {
+      "ca_id": 29492,
+      "spell_id": 800506
+    },
+    {
+      "ca_id": 29493,
+      "spell_id": 503584
+    },
+    {
+      "ca_id": 29500,
+      "spell_id": 801387
+    },
+    {
+      "ca_id": 29501,
+      "spell_id": 520453
+    },
+    {
+      "ca_id": 29503,
+      "spell_id": 520686
+    },
+    {
+      "ca_id": 29505,
+      "spell_id": 572752
+    },
+    {
+      "ca_id": 29506,
+      "spell_id": 681064
+    },
+    {
+      "ca_id": 29509,
+      "spell_id": 805647
+    },
+    {
+      "ca_id": 29510,
+      "spell_id": 500154
+    },
+    {
+      "ca_id": 29511,
+      "spell_id": 560094
+    },
+    {
+      "ca_id": 29513,
+      "spell_id": 704916
+    },
+    {
+      "ca_id": 29514,
+      "spell_id": 800637
+    },
+    {
+      "ca_id": 29515,
+      "spell_id": 560095
+    },
+    {
+      "ca_id": 29518,
+      "spell_id": 806400
+    },
+    {
+      "ca_id": 29519,
+      "spell_id": 704957
+    },
+    {
+      "ca_id": 29520,
+      "spell_id": 301198
+    },
+    {
+      "ca_id": 29521,
+      "spell_id": 712325
+    },
+    {
+      "ca_id": 29522,
+      "spell_id": 802631
+    },
+    {
+      "ca_id": 29528,
+      "spell_id": 705551
+    },
+    {
+      "ca_id": 29531,
+      "spell_id": 712299
+    },
+    {
+      "ca_id": 29533,
+      "spell_id": 712326
+    },
+    {
+      "ca_id": 29536,
+      "spell_id": 705550
+    },
+    {
+      "ca_id": 29541,
+      "spell_id": 570746
+    },
+    {
+      "ca_id": 29543,
+      "spell_id": 801074
+    },
+    {
+      "ca_id": 29544,
+      "spell_id": 704660
+    },
+    {
+      "ca_id": 29548,
+      "spell_id": 805483
+    },
+    {
+      "ca_id": 29550,
+      "spell_id": 706854
+    },
+    {
+      "ca_id": 29552,
+      "spell_id": 680959
+    },
+    {
+      "ca_id": 29554,
+      "spell_id": 525059
+    },
+    {
+      "ca_id": 29556,
+      "spell_id": 802168
+    },
+    {
+      "ca_id": 29558,
+      "spell_id": 704814
+    },
+    {
+      "ca_id": 29559,
+      "spell_id": 704275
+    },
+    {
+      "ca_id": 29560,
+      "spell_id": 520488
+    },
+    {
+      "ca_id": 29561,
+      "spell_id": 807146
+    },
+    {
+      "ca_id": 29564,
+      "spell_id": 807397
+    },
+    {
+      "ca_id": 29570,
+      "spell_id": 806302
+    },
+    {
+      "ca_id": 29571,
+      "spell_id": 804451
+    },
+    {
+      "ca_id": 29574,
+      "spell_id": 800878
+    },
+    {
+      "ca_id": 29575,
+      "spell_id": 706012
+    },
+    {
+      "ca_id": 29576,
+      "spell_id": 705996
+    },
+    {
+      "ca_id": 29577,
+      "spell_id": 804964
+    },
+    {
+      "ca_id": 29580,
+      "spell_id": 800882
+    },
+    {
+      "ca_id": 29582,
+      "spell_id": 504704
+    },
+    {
+      "ca_id": 29584,
+      "spell_id": 706209
+    },
+    {
+      "ca_id": 29586,
+      "spell_id": 630934
+    },
+    {
+      "ca_id": 29588,
+      "spell_id": 705966
+    },
+    {
+      "ca_id": 29589,
+      "spell_id": 800895
+    },
+    {
+      "ca_id": 29591,
+      "spell_id": 503970
+    },
+    {
+      "ca_id": 29592,
+      "spell_id": 800899
+    },
+    {
+      "ca_id": 29596,
+      "spell_id": 800914
+    },
+    {
+      "ca_id": 29598,
+      "spell_id": 504342
+    },
+    {
+      "ca_id": 29599,
+      "spell_id": 504736
+    },
+    {
+      "ca_id": 29601,
+      "spell_id": 800922
+    },
+    {
+      "ca_id": 29604,
+      "spell_id": 705409
+    },
+    {
+      "ca_id": 29607,
+      "spell_id": 300855
+    },
+    {
+      "ca_id": 29608,
+      "spell_id": 706354
+    },
+    {
+      "ca_id": 29610,
+      "spell_id": 705020
+    },
+    {
+      "ca_id": 29613,
+      "spell_id": 500235
+    },
+    {
+      "ca_id": 29615,
+      "spell_id": 804013
+    },
+    {
+      "ca_id": 29617,
+      "spell_id": 300889
+    },
+    {
+      "ca_id": 29619,
+      "spell_id": 300375
+    },
+    {
+      "ca_id": 29620,
+      "spell_id": 706295
+    },
+    {
+      "ca_id": 29621,
+      "spell_id": 801054
+    },
+    {
+      "ca_id": 29623,
+      "spell_id": 680723
+    },
+    {
+      "ca_id": 29624,
+      "spell_id": 807144
+    },
+    {
+      "ca_id": 29625,
+      "spell_id": 801065
+    },
+    {
+      "ca_id": 29628,
+      "spell_id": 806099
+    },
+    {
+      "ca_id": 29629,
+      "spell_id": 801952
+    },
+    {
+      "ca_id": 29630,
+      "spell_id": 800785
+    },
+    {
+      "ca_id": 29631,
+      "spell_id": 520783
+    },
+    {
+      "ca_id": 29633,
+      "spell_id": 500501
+    },
+    {
+      "ca_id": 29637,
+      "spell_id": 801086
+    },
+    {
+      "ca_id": 29639,
+      "spell_id": 705370
+    },
+    {
+      "ca_id": 29641,
+      "spell_id": 574350
+    },
+    {
+      "ca_id": 29642,
+      "spell_id": 704777
+    },
+    {
+      "ca_id": 29644,
+      "spell_id": 680703
+    },
+    {
+      "ca_id": 29645,
+      "spell_id": 704755
+    },
+    {
+      "ca_id": 29646,
+      "spell_id": 520481
+    },
+    {
+      "ca_id": 29647,
+      "spell_id": 801976
+    },
+    {
+      "ca_id": 29648,
+      "spell_id": 570231
+    },
+    {
+      "ca_id": 29649,
+      "spell_id": 801135
+    },
+    {
+      "ca_id": 29651,
+      "spell_id": 503637
+    },
+    {
+      "ca_id": 29653,
+      "spell_id": 563725
+    },
+    {
+      "ca_id": 29654,
+      "spell_id": 704889
+    },
+    {
+      "ca_id": 29656,
+      "spell_id": 804381
+    },
+    {
+      "ca_id": 29660,
+      "spell_id": 801191
+    },
+    {
+      "ca_id": 29661,
+      "spell_id": 504140
+    },
+    {
+      "ca_id": 29662,
+      "spell_id": 300994
+    },
+    {
+      "ca_id": 29663,
+      "spell_id": 704725
+    },
+    {
+      "ca_id": 29664,
+      "spell_id": 560305
+    },
+    {
+      "ca_id": 29667,
+      "spell_id": 706342
+    },
+    {
+      "ca_id": 29670,
+      "spell_id": 560541
+    },
+    {
+      "ca_id": 29677,
+      "spell_id": 706040
+    },
+    {
+      "ca_id": 29680,
+      "spell_id": 805851
+    },
+    {
+      "ca_id": 29681,
+      "spell_id": 560397
+    },
+    {
+      "ca_id": 29682,
+      "spell_id": 804444
+    },
+    {
+      "ca_id": 29684,
+      "spell_id": 802790
+    },
+    {
+      "ca_id": 29686,
+      "spell_id": 803904
+    },
+    {
+      "ca_id": 29688,
+      "spell_id": 707899
+    },
+    {
+      "ca_id": 29689,
+      "spell_id": 805190
+    },
+    {
+      "ca_id": 29693,
+      "spell_id": 801325
+    },
+    {
+      "ca_id": 29701,
+      "spell_id": 560966
+    },
+    {
+      "ca_id": 29704,
+      "spell_id": 803872
+    },
+    {
+      "ca_id": 29706,
+      "spell_id": 300530
+    },
+    {
+      "ca_id": 29707,
+      "spell_id": 804928
+    },
+    {
+      "ca_id": 29708,
+      "spell_id": 804929
+    },
+    {
+      "ca_id": 29712,
+      "spell_id": 712346
+    },
+    {
+      "ca_id": 29714,
+      "spell_id": 704180
+    },
+    {
+      "ca_id": 29715,
+      "spell_id": 801466
+    },
+    {
+      "ca_id": 29717,
+      "spell_id": 705295
+    },
+    {
+      "ca_id": 29720,
+      "spell_id": 801480
+    },
+    {
+      "ca_id": 29729,
+      "spell_id": 300871
+    },
+    {
+      "ca_id": 29736,
+      "spell_id": 704512
+    },
+    {
+      "ca_id": 29737,
+      "spell_id": 706545
+    },
+    {
+      "ca_id": 29740,
+      "spell_id": 705864
+    },
+    {
+      "ca_id": 29741,
+      "spell_id": 801663
+    },
+    {
+      "ca_id": 29743,
+      "spell_id": 806283
+    },
+    {
+      "ca_id": 29744,
+      "spell_id": 500957
+    },
+    {
+      "ca_id": 29747,
+      "spell_id": 501136
+    },
+    {
+      "ca_id": 29749,
+      "spell_id": 300663
+    },
+    {
+      "ca_id": 29752,
+      "spell_id": 807126
+    },
+    {
+      "ca_id": 29753,
+      "spell_id": 801689
+    },
+    {
+      "ca_id": 29754,
+      "spell_id": 500962
+    },
+    {
+      "ca_id": 29757,
+      "spell_id": 802756
+    },
+    {
+      "ca_id": 29761,
+      "spell_id": 525039
+    },
+    {
+      "ca_id": 29765,
+      "spell_id": 705788
+    },
+    {
+      "ca_id": 29768,
+      "spell_id": 801716
+    },
+    {
+      "ca_id": 29772,
+      "spell_id": 704676
+    },
+    {
+      "ca_id": 29773,
+      "spell_id": 560852
+    },
+    {
+      "ca_id": 29774,
+      "spell_id": 802121
+    },
+    {
+      "ca_id": 29777,
+      "spell_id": 806627
+    },
+    {
+      "ca_id": 29778,
+      "spell_id": 805427
+    },
+    {
+      "ca_id": 29779,
+      "spell_id": 301303
+    },
+    {
+      "ca_id": 29782,
+      "spell_id": 500995
+    },
+    {
+      "ca_id": 29783,
+      "spell_id": 802792
+    },
+    {
+      "ca_id": 29787,
+      "spell_id": 805369
+    },
+    {
+      "ca_id": 29788,
+      "spell_id": 807796
+    },
+    {
+      "ca_id": 29791,
+      "spell_id": 560444
+    },
+    {
+      "ca_id": 29793,
+      "spell_id": 804137
+    },
+    {
+      "ca_id": 29796,
+      "spell_id": 500263
+    },
+    {
+      "ca_id": 29797,
+      "spell_id": 801774
+    },
+    {
+      "ca_id": 29798,
+      "spell_id": 705359
+    },
+    {
+      "ca_id": 29799,
+      "spell_id": 801782
+    },
+    {
+      "ca_id": 29803,
+      "spell_id": 560906
+    },
+    {
+      "ca_id": 29812,
+      "spell_id": 300653
+    },
+    {
+      "ca_id": 29813,
+      "spell_id": 801809
+    },
+    {
+      "ca_id": 29814,
+      "spell_id": 804826
+    },
+    {
+      "ca_id": 29816,
+      "spell_id": 801801
+    },
+    {
+      "ca_id": 29818,
+      "spell_id": 706632
+    },
+    {
+      "ca_id": 29825,
+      "spell_id": 801827
+    },
+    {
+      "ca_id": 29828,
+      "spell_id": 800099
+    },
+    {
+      "ca_id": 29830,
+      "spell_id": 705661
+    },
+    {
+      "ca_id": 29831,
+      "spell_id": 705662
+    },
+    {
+      "ca_id": 29833,
+      "spell_id": 801851
+    },
+    {
+      "ca_id": 29834,
+      "spell_id": 806411
+    },
+    {
+      "ca_id": 29835,
+      "spell_id": 532751
+    },
+    {
+      "ca_id": 29836,
+      "spell_id": 806374
+    },
+    {
+      "ca_id": 29837,
+      "spell_id": 705646
+    },
+    {
+      "ca_id": 29839,
+      "spell_id": 504401
+    },
+    {
+      "ca_id": 29842,
+      "spell_id": 704602
+    },
+    {
+      "ca_id": 29845,
+      "spell_id": 800209
+    },
+    {
+      "ca_id": 29849,
+      "spell_id": 804219
+    },
+    {
+      "ca_id": 29852,
+      "spell_id": 705127
+    },
+    {
+      "ca_id": 29854,
+      "spell_id": 520884
+    },
+    {
+      "ca_id": 29857,
+      "spell_id": 520937
+    },
+    {
+      "ca_id": 29858,
+      "spell_id": 806611
+    },
+    {
+      "ca_id": 29860,
+      "spell_id": 503863
+    },
+    {
+      "ca_id": 29861,
+      "spell_id": 805675
+    },
+    {
+      "ca_id": 29864,
+      "spell_id": 806321
+    },
+    {
+      "ca_id": 29865,
+      "spell_id": 704715
+    },
+    {
+      "ca_id": 29866,
+      "spell_id": 500338
+    },
+    {
+      "ca_id": 29871,
+      "spell_id": 504285
+    },
+    {
+      "ca_id": 29872,
+      "spell_id": 804811
+    },
+    {
+      "ca_id": 29876,
+      "spell_id": 801961
+    },
+    {
+      "ca_id": 29878,
+      "spell_id": 707435
+    },
+    {
+      "ca_id": 29880,
+      "spell_id": 300270
+    },
+    {
+      "ca_id": 29882,
+      "spell_id": 802044
+    },
+    {
+      "ca_id": 29886,
+      "spell_id": 704732
+    },
+    {
+      "ca_id": 29887,
+      "spell_id": 520590
+    },
+    {
+      "ca_id": 29891,
+      "spell_id": 801987
+    },
+    {
+      "ca_id": 29892,
+      "spell_id": 704759
+    },
+    {
+      "ca_id": 29894,
+      "spell_id": 504004
+    },
+    {
+      "ca_id": 29895,
+      "spell_id": 560440
+    },
+    {
+      "ca_id": 29896,
+      "spell_id": 801996
+    },
+    {
+      "ca_id": 29901,
+      "spell_id": 802140
+    },
+    {
+      "ca_id": 29904,
+      "spell_id": 560208
+    },
+    {
+      "ca_id": 29907,
+      "spell_id": 802019
+    },
+    {
+      "ca_id": 29911,
+      "spell_id": 524697
+    },
+    {
+      "ca_id": 29914,
+      "spell_id": 560688
+    },
+    {
+      "ca_id": 29915,
+      "spell_id": 300291
+    },
+    {
+      "ca_id": 29916,
+      "spell_id": 680574
+    },
+    {
+      "ca_id": 29918,
+      "spell_id": 681087
+    },
+    {
+      "ca_id": 29920,
+      "spell_id": 572064
+    },
+    {
+      "ca_id": 29921,
+      "spell_id": 802052
+    },
+    {
+      "ca_id": 29922,
+      "spell_id": 300483
+    },
+    {
+      "ca_id": 29923,
+      "spell_id": 803905
+    },
+    {
+      "ca_id": 29924,
+      "spell_id": 806109
+    },
+    {
+      "ca_id": 29926,
+      "spell_id": 561216
+    },
+    {
+      "ca_id": 29927,
+      "spell_id": 801899
+    },
+    {
+      "ca_id": 29928,
+      "spell_id": 802087
+    },
+    {
+      "ca_id": 29929,
+      "spell_id": 705912
+    },
+    {
+      "ca_id": 29930,
+      "spell_id": 712312
+    },
+    {
+      "ca_id": 29933,
+      "spell_id": 704368
+    },
+    {
+      "ca_id": 29935,
+      "spell_id": 300956
+    },
+    {
+      "ca_id": 29940,
+      "spell_id": 520218
+    },
+    {
+      "ca_id": 29943,
+      "spell_id": 707007
+    },
+    {
+      "ca_id": 29946,
+      "spell_id": 560730
+    },
+    {
+      "ca_id": 29947,
+      "spell_id": 680498
+    },
+    {
+      "ca_id": 29949,
+      "spell_id": 802138
+    },
+    {
+      "ca_id": 29950,
+      "spell_id": 802139
+    },
+    {
+      "ca_id": 29951,
+      "spell_id": 301251
+    },
+    {
+      "ca_id": 29952,
+      "spell_id": 680253
+    },
+    {
+      "ca_id": 29953,
+      "spell_id": 681341
+    },
+    {
+      "ca_id": 29955,
+      "spell_id": 524952
+    },
+    {
+      "ca_id": 29962,
+      "spell_id": 92128
+    },
+    {
+      "ca_id": 29964,
+      "spell_id": 704812
+    },
+    {
+      "ca_id": 29966,
+      "spell_id": 520770
+    },
+    {
+      "ca_id": 29968,
+      "spell_id": 560639
+    },
+    {
+      "ca_id": 29969,
+      "spell_id": 706514
+    },
+    {
+      "ca_id": 29970,
+      "spell_id": 300543
+    },
+    {
+      "ca_id": 29971,
+      "spell_id": 704513
+    },
+    {
+      "ca_id": 29972,
+      "spell_id": 802198
+    },
+    {
+      "ca_id": 29974,
+      "spell_id": 560662
+    },
+    {
+      "ca_id": 29977,
+      "spell_id": 807743
+    },
+    {
+      "ca_id": 29978,
+      "spell_id": 705925
+    },
+    {
+      "ca_id": 29981,
+      "spell_id": 705928
+    },
+    {
+      "ca_id": 29984,
+      "spell_id": 706365
+    },
+    {
+      "ca_id": 29986,
+      "spell_id": 802276
+    },
+    {
+      "ca_id": 29988,
+      "spell_id": 802004
+    },
+    {
+      "ca_id": 29992,
+      "spell_id": 803738
+    },
+    {
+      "ca_id": 29996,
+      "spell_id": 801121
+    },
+    {
+      "ca_id": 29998,
+      "spell_id": 705338
+    },
+    {
+      "ca_id": 29999,
+      "spell_id": 805155
+    },
+    {
+      "ca_id": 30000,
+      "spell_id": 802297
+    },
+    {
+      "ca_id": 30003,
+      "spell_id": 802300
+    },
+    {
+      "ca_id": 30013,
+      "spell_id": 706502
+    },
+    {
+      "ca_id": 30016,
+      "spell_id": 520294
+    },
+    {
+      "ca_id": 30019,
+      "spell_id": 500258
+    },
+    {
+      "ca_id": 30020,
+      "spell_id": 802888
+    },
+    {
+      "ca_id": 30022,
+      "spell_id": 503757
+    },
+    {
+      "ca_id": 30026,
+      "spell_id": 801104
+    },
+    {
+      "ca_id": 30027,
+      "spell_id": 807204
+    },
+    {
+      "ca_id": 30029,
+      "spell_id": 705572
+    },
+    {
+      "ca_id": 30030,
+      "spell_id": 706672
+    },
+    {
+      "ca_id": 30031,
+      "spell_id": 803013
+    },
+    {
+      "ca_id": 30032,
+      "spell_id": 500270
+    },
+    {
+      "ca_id": 30033,
+      "spell_id": 300944
+    },
+    {
+      "ca_id": 30034,
+      "spell_id": 705565
+    },
+    {
+      "ca_id": 30038,
+      "spell_id": 805205
+    },
+    {
+      "ca_id": 30042,
+      "spell_id": 705186
+    },
+    {
+      "ca_id": 30045,
+      "spell_id": 707319
+    },
+    {
+      "ca_id": 30046,
+      "spell_id": 572372
+    },
+    {
+      "ca_id": 30049,
+      "spell_id": 680276
+    },
+    {
+      "ca_id": 30050,
+      "spell_id": 705034
+    },
+    {
+      "ca_id": 30051,
+      "spell_id": 705044
+    },
+    {
+      "ca_id": 30053,
+      "spell_id": 570015
+    },
+    {
+      "ca_id": 30054,
+      "spell_id": 524600
+    },
+    {
+      "ca_id": 30056,
+      "spell_id": 705364
+    },
+    {
+      "ca_id": 30057,
+      "spell_id": 800313
+    },
+    {
+      "ca_id": 30059,
+      "spell_id": 705330
+    },
+    {
+      "ca_id": 30060,
+      "spell_id": 560410
+    },
+    {
+      "ca_id": 30061,
+      "spell_id": 707716
+    },
+    {
+      "ca_id": 30063,
+      "spell_id": 680953
+    },
+    {
+      "ca_id": 30066,
+      "spell_id": 705284
+    },
+    {
+      "ca_id": 30067,
+      "spell_id": 520034
+    },
+    {
+      "ca_id": 30070,
+      "spell_id": 560096
+    },
+    {
+      "ca_id": 30071,
+      "spell_id": 503681
+    },
+    {
+      "ca_id": 30073,
+      "spell_id": 504352
+    },
+    {
+      "ca_id": 30078,
+      "spell_id": 560266
+    },
+    {
+      "ca_id": 30080,
+      "spell_id": 803196
+    },
+    {
+      "ca_id": 30081,
+      "spell_id": 705876
+    },
+    {
+      "ca_id": 30084,
+      "spell_id": 705999
+    },
+    {
+      "ca_id": 30087,
+      "spell_id": 706001
+    },
+    {
+      "ca_id": 30096,
+      "spell_id": 804230
+    },
+    {
+      "ca_id": 30097,
+      "spell_id": 803956
+    },
+    {
+      "ca_id": 30098,
+      "spell_id": 705356
+    },
+    {
+      "ca_id": 30100,
+      "spell_id": 524694
+    },
+    {
+      "ca_id": 30104,
+      "spell_id": 560510
+    },
+    {
+      "ca_id": 30105,
+      "spell_id": 803980
+    },
+    {
+      "ca_id": 30107,
+      "spell_id": 805258
+    },
+    {
+      "ca_id": 30109,
+      "spell_id": 561108
+    },
+    {
+      "ca_id": 30111,
+      "spell_id": 300791
+    },
+    {
+      "ca_id": 30112,
+      "spell_id": 705424
+    },
+    {
+      "ca_id": 30113,
+      "spell_id": 500483
+    },
+    {
+      "ca_id": 30116,
+      "spell_id": 705403
+    },
+    {
+      "ca_id": 30118,
+      "spell_id": 803998
+    },
+    {
+      "ca_id": 30119,
+      "spell_id": 805719
+    },
+    {
+      "ca_id": 30124,
+      "spell_id": 804354
+    },
+    {
+      "ca_id": 30125,
+      "spell_id": 804014
+    },
+    {
+      "ca_id": 30126,
+      "spell_id": 804278
+    },
+    {
+      "ca_id": 30127,
+      "spell_id": 705692
+    },
+    {
+      "ca_id": 30132,
+      "spell_id": 500042
+    },
+    {
+      "ca_id": 30133,
+      "spell_id": 503680
+    },
+    {
+      "ca_id": 30136,
+      "spell_id": 300365
+    },
+    {
+      "ca_id": 30137,
+      "spell_id": 504070
+    },
+    {
+      "ca_id": 30138,
+      "spell_id": 705709
+    },
+    {
+      "ca_id": 30139,
+      "spell_id": 705717
+    },
+    {
+      "ca_id": 30141,
+      "spell_id": 705721
+    },
+    {
+      "ca_id": 30144,
+      "spell_id": 705376
+    },
+    {
+      "ca_id": 30145,
+      "spell_id": 804047
+    },
+    {
+      "ca_id": 30147,
+      "spell_id": 705921
+    },
+    {
+      "ca_id": 30148,
+      "spell_id": 300348
+    },
+    {
+      "ca_id": 30153,
+      "spell_id": 503651
+    },
+    {
+      "ca_id": 30154,
+      "spell_id": 520639
+    },
+    {
+      "ca_id": 30158,
+      "spell_id": 801103
+    },
+    {
+      "ca_id": 30162,
+      "spell_id": 804139
+    },
+    {
+      "ca_id": 30163,
+      "spell_id": 804138
+    },
+    {
+      "ca_id": 30166,
+      "spell_id": 706804
+    },
+    {
+      "ca_id": 30167,
+      "spell_id": 561397
+    },
+    {
+      "ca_id": 30173,
+      "spell_id": 807376
+    },
+    {
+      "ca_id": 30176,
+      "spell_id": 800081
+    },
+    {
+      "ca_id": 30177,
+      "spell_id": 804169
+    },
+    {
+      "ca_id": 30178,
+      "spell_id": 300387
+    },
+    {
+      "ca_id": 30179,
+      "spell_id": 805703
+    },
+    {
+      "ca_id": 30180,
+      "spell_id": 705055
+    },
+    {
+      "ca_id": 30185,
+      "spell_id": 504903
+    },
+    {
+      "ca_id": 30186,
+      "spell_id": 680255
+    },
+    {
+      "ca_id": 30187,
+      "spell_id": 680238
+    },
+    {
+      "ca_id": 30188,
+      "spell_id": 804194
+    },
+    {
+      "ca_id": 30190,
+      "spell_id": 801959
+    },
+    {
+      "ca_id": 30191,
+      "spell_id": 804197
+    },
+    {
+      "ca_id": 30192,
+      "spell_id": 706683
+    },
+    {
+      "ca_id": 30193,
+      "spell_id": 704624
+    },
+    {
+      "ca_id": 30194,
+      "spell_id": 300585
+    },
+    {
+      "ca_id": 30195,
+      "spell_id": 572783
+    },
+    {
+      "ca_id": 30196,
+      "spell_id": 500012
+    },
+    {
+      "ca_id": 30198,
+      "spell_id": 800782
+    },
+    {
+      "ca_id": 30200,
+      "spell_id": 706425
+    },
+    {
+      "ca_id": 30202,
+      "spell_id": 801963
+    },
+    {
+      "ca_id": 30203,
+      "spell_id": 802100
+    },
+    {
+      "ca_id": 30205,
+      "spell_id": 525060
+    },
+    {
+      "ca_id": 30206,
+      "spell_id": 800818
+    },
+    {
+      "ca_id": 30208,
+      "spell_id": 705564
+    },
+    {
+      "ca_id": 30210,
+      "spell_id": 704582
+    },
+    {
+      "ca_id": 30211,
+      "spell_id": 804250
+    },
+    {
+      "ca_id": 30212,
+      "spell_id": 300349
+    },
+    {
+      "ca_id": 30213,
+      "spell_id": 300343
+    },
+    {
+      "ca_id": 30214,
+      "spell_id": 804249
+    },
+    {
+      "ca_id": 30224,
+      "spell_id": 560001
+    },
+    {
+      "ca_id": 30229,
+      "spell_id": 301302
+    },
+    {
+      "ca_id": 30235,
+      "spell_id": 300390
+    },
+    {
+      "ca_id": 30236,
+      "spell_id": 804883
+    },
+    {
+      "ca_id": 30237,
+      "spell_id": 300388
+    },
+    {
+      "ca_id": 30238,
+      "spell_id": 704717
+    },
+    {
+      "ca_id": 30239,
+      "spell_id": 801155
+    },
+    {
+      "ca_id": 30240,
+      "spell_id": 536216
+    },
+    {
+      "ca_id": 30241,
+      "spell_id": 680784
+    },
+    {
+      "ca_id": 30249,
+      "spell_id": 805847
+    },
+    {
+      "ca_id": 30250,
+      "spell_id": 706071
+    },
+    {
+      "ca_id": 30251,
+      "spell_id": 520922
+    },
+    {
+      "ca_id": 30254,
+      "spell_id": 500696
+    },
+    {
+      "ca_id": 30256,
+      "spell_id": 707551
+    },
+    {
+      "ca_id": 30257,
+      "spell_id": 801281
+    },
+    {
+      "ca_id": 30260,
+      "spell_id": 806315
+    },
+    {
+      "ca_id": 30261,
+      "spell_id": 520188
+    },
+    {
+      "ca_id": 30264,
+      "spell_id": 806162
+    },
+    {
+      "ca_id": 30265,
+      "spell_id": 520800
+    },
+    {
+      "ca_id": 30267,
+      "spell_id": 520173
+    },
+    {
+      "ca_id": 30268,
+      "spell_id": 804462
+    },
+    {
+      "ca_id": 30269,
+      "spell_id": 804441
+    },
+    {
+      "ca_id": 30276,
+      "spell_id": 555729
+    },
+    {
+      "ca_id": 30277,
+      "spell_id": 800857
+    },
+    {
+      "ca_id": 30279,
+      "spell_id": 520386
+    },
+    {
+      "ca_id": 30280,
+      "spell_id": 574309
+    },
+    {
+      "ca_id": 30282,
+      "spell_id": 520171
+    },
+    {
+      "ca_id": 30287,
+      "spell_id": 804912
+    },
+    {
+      "ca_id": 30288,
+      "spell_id": 806414
+    },
+    {
+      "ca_id": 30290,
+      "spell_id": 504260
+    },
+    {
+      "ca_id": 30291,
+      "spell_id": 560256
+    },
+    {
+      "ca_id": 30292,
+      "spell_id": 704692
+    },
+    {
+      "ca_id": 30293,
+      "spell_id": 704115
+    },
+    {
+      "ca_id": 30294,
+      "spell_id": 704653
+    },
+    {
+      "ca_id": 30295,
+      "spell_id": 804605
+    },
+    {
+      "ca_id": 30299,
+      "spell_id": 560057
+    },
+    {
+      "ca_id": 30300,
+      "spell_id": 804611
+    },
+    {
+      "ca_id": 30301,
+      "spell_id": 560822
+    },
+    {
+      "ca_id": 30302,
+      "spell_id": 300490
+    },
+    {
+      "ca_id": 30304,
+      "spell_id": 503636
+    },
+    {
+      "ca_id": 30307,
+      "spell_id": 804632
+    },
+    {
+      "ca_id": 30308,
+      "spell_id": 560859
+    },
+    {
+      "ca_id": 30309,
+      "spell_id": 680652
+    },
+    {
+      "ca_id": 30310,
+      "spell_id": 560276
+    },
+    {
+      "ca_id": 30311,
+      "spell_id": 300321
+    },
+    {
+      "ca_id": 30312,
+      "spell_id": 806024
+    },
+    {
+      "ca_id": 30315,
+      "spell_id": 520056
+    },
+    {
+      "ca_id": 30316,
+      "spell_id": 804661
+    },
+    {
+      "ca_id": 30323,
+      "spell_id": 706190
+    },
+    {
+      "ca_id": 30324,
+      "spell_id": 805186
+    },
+    {
+      "ca_id": 30327,
+      "spell_id": 705546
+    },
+    {
+      "ca_id": 30333,
+      "spell_id": 804684
+    },
+    {
+      "ca_id": 30334,
+      "spell_id": 560074
+    },
+    {
+      "ca_id": 30342,
+      "spell_id": 706247
+    },
+    {
+      "ca_id": 30346,
+      "spell_id": 300740
+    },
+    {
+      "ca_id": 30350,
+      "spell_id": 705050
+    },
+    {
+      "ca_id": 30351,
+      "spell_id": 573057
+    },
+    {
+      "ca_id": 30352,
+      "spell_id": 802839
+    },
+    {
+      "ca_id": 30355,
+      "spell_id": 560012
+    },
+    {
+      "ca_id": 30360,
+      "spell_id": 560315
+    },
+    {
+      "ca_id": 30369,
+      "spell_id": 804739
+    },
+    {
+      "ca_id": 30374,
+      "spell_id": 804730
+    },
+    {
+      "ca_id": 30377,
+      "spell_id": 560563
+    },
+    {
+      "ca_id": 30378,
+      "spell_id": 804750
+    },
+    {
+      "ca_id": 30379,
+      "spell_id": 503690
+    },
+    {
+      "ca_id": 30386,
+      "spell_id": 705161
+    },
+    {
+      "ca_id": 30387,
+      "spell_id": 705212
+    },
+    {
+      "ca_id": 30393,
+      "spell_id": 704958
+    },
+    {
+      "ca_id": 30396,
+      "spell_id": 804193
+    },
+    {
+      "ca_id": 30399,
+      "spell_id": 681358
+    },
+    {
+      "ca_id": 30400,
+      "spell_id": 524907
+    },
+    {
+      "ca_id": 30401,
+      "spell_id": 504100
+    },
+    {
+      "ca_id": 30402,
+      "spell_id": 800766
+    },
+    {
+      "ca_id": 30403,
+      "spell_id": 704824
+    },
+    {
+      "ca_id": 30404,
+      "spell_id": 805255
+    },
+    {
+      "ca_id": 30405,
+      "spell_id": 804823
+    },
+    {
+      "ca_id": 30406,
+      "spell_id": 800699
+    },
+    {
+      "ca_id": 30408,
+      "spell_id": 570191
+    },
+    {
+      "ca_id": 30410,
+      "spell_id": 804830
+    },
+    {
+      "ca_id": 30418,
+      "spell_id": 524865
+    },
+    {
+      "ca_id": 30419,
+      "spell_id": 807489
+    },
+    {
+      "ca_id": 30420,
+      "spell_id": 680661
+    },
+    {
+      "ca_id": 30421,
+      "spell_id": 572855
+    },
+    {
+      "ca_id": 30422,
+      "spell_id": 705780
+    },
+    {
+      "ca_id": 30428,
+      "spell_id": 804879
+    },
+    {
+      "ca_id": 30433,
+      "spell_id": 704150
+    },
+    {
+      "ca_id": 30434,
+      "spell_id": 802283
+    },
+    {
+      "ca_id": 30436,
+      "spell_id": 801204
+    },
+    {
+      "ca_id": 30437,
+      "spell_id": 706357
+    },
+    {
+      "ca_id": 30438,
+      "spell_id": 524765
+    },
+    {
+      "ca_id": 30439,
+      "spell_id": 520534
+    },
+    {
+      "ca_id": 30440,
+      "spell_id": 705253
+    },
+    {
+      "ca_id": 30443,
+      "spell_id": 704175
+    },
+    {
+      "ca_id": 30445,
+      "spell_id": 705300
+    },
+    {
+      "ca_id": 30448,
+      "spell_id": 300520
+    },
+    {
+      "ca_id": 30449,
+      "spell_id": 572548
+    },
+    {
+      "ca_id": 30450,
+      "spell_id": 573452
+    },
+    {
+      "ca_id": 30451,
+      "spell_id": 707364
+    },
+    {
+      "ca_id": 30453,
+      "spell_id": 705286
+    },
+    {
+      "ca_id": 30455,
+      "spell_id": 504561
+    },
+    {
+      "ca_id": 30459,
+      "spell_id": 705053
+    },
+    {
+      "ca_id": 30461,
+      "spell_id": 800360
+    },
+    {
+      "ca_id": 30462,
+      "spell_id": 800077
+    },
+    {
+      "ca_id": 30463,
+      "spell_id": 572370
+    },
+    {
+      "ca_id": 30464,
+      "spell_id": 800871
+    },
+    {
+      "ca_id": 30465,
+      "spell_id": 804962
+    },
+    {
+      "ca_id": 30469,
+      "spell_id": 504375
+    },
+    {
+      "ca_id": 30471,
+      "spell_id": 706036
+    },
+    {
+      "ca_id": 30472,
+      "spell_id": 706038
+    },
+    {
+      "ca_id": 30473,
+      "spell_id": 706271
+    },
+    {
+      "ca_id": 30477,
+      "spell_id": 804982
+    },
+    {
+      "ca_id": 30479,
+      "spell_id": 804986
+    },
+    {
+      "ca_id": 30481,
+      "spell_id": 503923
+    },
+    {
+      "ca_id": 30482,
+      "spell_id": 707563
+    },
+    {
+      "ca_id": 30483,
+      "spell_id": 681057
+    },
+    {
+      "ca_id": 30485,
+      "spell_id": 504407
+    },
+    {
+      "ca_id": 30487,
+      "spell_id": 706953
+    },
+    {
+      "ca_id": 30488,
+      "spell_id": 504866
+    },
+    {
+      "ca_id": 30495,
+      "spell_id": 805044
+    },
+    {
+      "ca_id": 30497,
+      "spell_id": 561215
+    },
+    {
+      "ca_id": 30498,
+      "spell_id": 805074
+    },
+    {
+      "ca_id": 30499,
+      "spell_id": 705991
+    },
+    {
+      "ca_id": 30505,
+      "spell_id": 805103
+    },
+    {
+      "ca_id": 30508,
+      "spell_id": 560055
+    },
+    {
+      "ca_id": 30511,
+      "spell_id": 572103
+    },
+    {
+      "ca_id": 30512,
+      "spell_id": 707604
+    },
+    {
+      "ca_id": 30515,
+      "spell_id": 680500
+    },
+    {
+      "ca_id": 30516,
+      "spell_id": 680487
+    },
+    {
+      "ca_id": 30517,
+      "spell_id": 560892
+    },
+    {
+      "ca_id": 30520,
+      "spell_id": 804056
+    },
+    {
+      "ca_id": 30522,
+      "spell_id": 706926
+    },
+    {
+      "ca_id": 30523,
+      "spell_id": 807128
+    },
+    {
+      "ca_id": 30524,
+      "spell_id": 805140
+    },
+    {
+      "ca_id": 30526,
+      "spell_id": 527268
+    },
+    {
+      "ca_id": 30528,
+      "spell_id": 704514
+    },
+    {
+      "ca_id": 30529,
+      "spell_id": 804891
+    },
+    {
+      "ca_id": 30530,
+      "spell_id": 582901
+    },
+    {
+      "ca_id": 30533,
+      "spell_id": 805181
+    },
+    {
+      "ca_id": 30534,
+      "spell_id": 680995
+    },
+    {
+      "ca_id": 30535,
+      "spell_id": 803030
+    },
+    {
+      "ca_id": 30536,
+      "spell_id": 805195
+    },
+    {
+      "ca_id": 30543,
+      "spell_id": 712484
+    },
+    {
+      "ca_id": 30545,
+      "spell_id": 704556
+    },
+    {
+      "ca_id": 30546,
+      "spell_id": 524735
+    },
+    {
+      "ca_id": 30548,
+      "spell_id": 805194
+    },
+    {
+      "ca_id": 30549,
+      "spell_id": 520371
+    },
+    {
+      "ca_id": 30550,
+      "spell_id": 805716
+    },
+    {
+      "ca_id": 30551,
+      "spell_id": 705414
+    },
+    {
+      "ca_id": 30552,
+      "spell_id": 525001
+    },
+    {
+      "ca_id": 30553,
+      "spell_id": 704613
+    },
+    {
+      "ca_id": 30554,
+      "spell_id": 705129
+    },
+    {
+      "ca_id": 30556,
+      "spell_id": 706267
+    },
+    {
+      "ca_id": 30557,
+      "spell_id": 805240
+    },
+    {
+      "ca_id": 30558,
+      "spell_id": 805239
+    },
+    {
+      "ca_id": 30559,
+      "spell_id": 800225
+    },
+    {
+      "ca_id": 30560,
+      "spell_id": 560549
+    },
+    {
+      "ca_id": 30561,
+      "spell_id": 300470
+    },
+    {
+      "ca_id": 30563,
+      "spell_id": 805249
+    },
+    {
+      "ca_id": 30565,
+      "spell_id": 704612
+    },
+    {
+      "ca_id": 30566,
+      "spell_id": 704611
+    },
+    {
+      "ca_id": 30567,
+      "spell_id": 520254
+    },
+    {
+      "ca_id": 30569,
+      "spell_id": 806980
+    },
+    {
+      "ca_id": 30571,
+      "spell_id": 560734
+    },
+    {
+      "ca_id": 30572,
+      "spell_id": 503552
+    },
+    {
+      "ca_id": 30573,
+      "spell_id": 807723
+    },
+    {
+      "ca_id": 30574,
+      "spell_id": 680196
+    },
+    {
+      "ca_id": 30575,
+      "spell_id": 805308
+    },
+    {
+      "ca_id": 30577,
+      "spell_id": 705811
+    },
+    {
+      "ca_id": 30579,
+      "spell_id": 707259
+    },
+    {
+      "ca_id": 30580,
+      "spell_id": 707246
+    },
+    {
+      "ca_id": 30581,
+      "spell_id": 500600
+    },
+    {
+      "ca_id": 30583,
+      "spell_id": 560754
+    },
+    {
+      "ca_id": 30586,
+      "spell_id": 707239
+    },
+    {
+      "ca_id": 30591,
+      "spell_id": 504446
+    },
+    {
+      "ca_id": 30595,
+      "spell_id": 801978
+    },
+    {
+      "ca_id": 30596,
+      "spell_id": 707209
+    },
+    {
+      "ca_id": 30599,
+      "spell_id": 537208
+    },
+    {
+      "ca_id": 30600,
+      "spell_id": 805428
+    },
+    {
+      "ca_id": 30601,
+      "spell_id": 680977
+    },
+    {
+      "ca_id": 30602,
+      "spell_id": 805378
+    },
+    {
+      "ca_id": 30603,
+      "spell_id": 560040
+    },
+    {
+      "ca_id": 30605,
+      "spell_id": 704680
+    },
+    {
+      "ca_id": 30606,
+      "spell_id": 804983
+    },
+    {
+      "ca_id": 30607,
+      "spell_id": 524822
+    },
+    {
+      "ca_id": 30608,
+      "spell_id": 527023
+    },
+    {
+      "ca_id": 30610,
+      "spell_id": 300512
+    },
+    {
+      "ca_id": 30611,
+      "spell_id": 705266
+    },
+    {
+      "ca_id": 30613,
+      "spell_id": 712437
+    },
+    {
+      "ca_id": 30614,
+      "spell_id": 805417
+    },
+    {
+      "ca_id": 30615,
+      "spell_id": 805422
+    },
+    {
+      "ca_id": 30617,
+      "spell_id": 805429
+    },
+    {
+      "ca_id": 30619,
+      "spell_id": 805424
+    },
+    {
+      "ca_id": 30620,
+      "spell_id": 705745
+    },
+    {
+      "ca_id": 30621,
+      "spell_id": 531135
+    },
+    {
+      "ca_id": 30622,
+      "spell_id": 500331
+    },
+    {
+      "ca_id": 30624,
+      "spell_id": 704740
+    },
+    {
+      "ca_id": 30625,
+      "spell_id": 805437
+    },
+    {
+      "ca_id": 30626,
+      "spell_id": 805439
+    },
+    {
+      "ca_id": 30628,
+      "spell_id": 301299
+    },
+    {
+      "ca_id": 30630,
+      "spell_id": 704861
+    },
+    {
+      "ca_id": 30633,
+      "spell_id": 800145
+    },
+    {
+      "ca_id": 30634,
+      "spell_id": 706872
+    },
+    {
+      "ca_id": 30637,
+      "spell_id": 704855
+    },
+    {
+      "ca_id": 30638,
+      "spell_id": 560561
+    },
+    {
+      "ca_id": 30639,
+      "spell_id": 802120
+    },
+    {
+      "ca_id": 30642,
+      "spell_id": 806736
+    },
+    {
+      "ca_id": 30643,
+      "spell_id": 524875
+    },
+    {
+      "ca_id": 30644,
+      "spell_id": 704845
+    },
+    {
+      "ca_id": 30651,
+      "spell_id": 500135
+    },
+    {
+      "ca_id": 30653,
+      "spell_id": 807160
+    },
+    {
+      "ca_id": 30654,
+      "spell_id": 704795
+    },
+    {
+      "ca_id": 30656,
+      "spell_id": 805508
+    },
+    {
+      "ca_id": 30659,
+      "spell_id": 801146
+    },
+    {
+      "ca_id": 30660,
+      "spell_id": 805524
+    },
+    {
+      "ca_id": 30661,
+      "spell_id": 680611
+    },
+    {
+      "ca_id": 30663,
+      "spell_id": 680810
+    },
+    {
+      "ca_id": 30665,
+      "spell_id": 805550
+    },
+    {
+      "ca_id": 30666,
+      "spell_id": 806779
+    },
+    {
+      "ca_id": 30668,
+      "spell_id": 803185
+    },
+    {
+      "ca_id": 30669,
+      "spell_id": 805563
+    },
+    {
+      "ca_id": 30671,
+      "spell_id": 706245
+    },
+    {
+      "ca_id": 30674,
+      "spell_id": 707079
+    },
+    {
+      "ca_id": 30676,
+      "spell_id": 504758
+    },
+    {
+      "ca_id": 30678,
+      "spell_id": 801096
+    },
+    {
+      "ca_id": 30680,
+      "spell_id": 504394
+    },
+    {
+      "ca_id": 30681,
+      "spell_id": 707081
+    },
+    {
+      "ca_id": 30682,
+      "spell_id": 680656
+    },
+    {
+      "ca_id": 30684,
+      "spell_id": 800612
+    },
+    {
+      "ca_id": 30689,
+      "spell_id": 504193
+    },
+    {
+      "ca_id": 30690,
+      "spell_id": 806058
+    },
+    {
+      "ca_id": 30691,
+      "spell_id": 300374
+    },
+    {
+      "ca_id": 30694,
+      "spell_id": 573036
+    },
+    {
+      "ca_id": 30695,
+      "spell_id": 801061
+    },
+    {
+      "ca_id": 30697,
+      "spell_id": 804786
+    },
+    {
+      "ca_id": 30699,
+      "spell_id": 706756
+    },
+    {
+      "ca_id": 30700,
+      "spell_id": 805678
+    },
+    {
+      "ca_id": 30701,
+      "spell_id": 805679
+    },
+    {
+      "ca_id": 30702,
+      "spell_id": 707254
+    },
+    {
+      "ca_id": 30704,
+      "spell_id": 704997
+    },
+    {
+      "ca_id": 30705,
+      "spell_id": 707390
+    },
+    {
+      "ca_id": 30706,
+      "spell_id": 704959
+    },
+    {
+      "ca_id": 30707,
+      "spell_id": 802619
+    },
+    {
+      "ca_id": 30709,
+      "spell_id": 805671
+    },
+    {
+      "ca_id": 30710,
+      "spell_id": 802610
+    },
+    {
+      "ca_id": 30713,
+      "spell_id": 704988
+    },
+    {
+      "ca_id": 30714,
+      "spell_id": 704994
+    },
+    {
+      "ca_id": 30715,
+      "spell_id": 560924
+    },
+    {
+      "ca_id": 30720,
+      "spell_id": 803992
+    },
+    {
+      "ca_id": 30722,
+      "spell_id": 301213
+    },
+    {
+      "ca_id": 30728,
+      "spell_id": 520229
+    },
+    {
+      "ca_id": 30732,
+      "spell_id": 300968
+    },
+    {
+      "ca_id": 30733,
+      "spell_id": 807172
+    },
+    {
+      "ca_id": 30734,
+      "spell_id": 705615
+    },
+    {
+      "ca_id": 30735,
+      "spell_id": 805750
+    },
+    {
+      "ca_id": 30736,
+      "spell_id": 803638
+    },
+    {
+      "ca_id": 30738,
+      "spell_id": 805756
+    },
+    {
+      "ca_id": 30739,
+      "spell_id": 804026
+    },
+    {
+      "ca_id": 30748,
+      "spell_id": 705524
+    },
+    {
+      "ca_id": 30749,
+      "spell_id": 706021
+    },
+    {
+      "ca_id": 30754,
+      "spell_id": 705211
+    },
+    {
+      "ca_id": 30758,
+      "spell_id": 521211
+    },
+    {
+      "ca_id": 30760,
+      "spell_id": 704876
+    },
+    {
+      "ca_id": 30762,
+      "spell_id": 500918
+    },
+    {
+      "ca_id": 30763,
+      "spell_id": 805810
+    },
+    {
+      "ca_id": 30764,
+      "spell_id": 705156
+    },
+    {
+      "ca_id": 30766,
+      "spell_id": 520647
+    },
+    {
+      "ca_id": 30767,
+      "spell_id": 800152
+    },
+    {
+      "ca_id": 30769,
+      "spell_id": 704778
+    },
+    {
+      "ca_id": 30770,
+      "spell_id": 707207
+    },
+    {
+      "ca_id": 30771,
+      "spell_id": 560586
+    },
+    {
+      "ca_id": 30773,
+      "spell_id": 926591
+    },
+    {
+      "ca_id": 30776,
+      "spell_id": 592008
+    },
+    {
+      "ca_id": 30780,
+      "spell_id": 704488
+    },
+    {
+      "ca_id": 30784,
+      "spell_id": 706148
+    },
+    {
+      "ca_id": 30785,
+      "spell_id": 300742
+    },
+    {
+      "ca_id": 30792,
+      "spell_id": 705204
+    },
+    {
+      "ca_id": 30793,
+      "spell_id": 803195
+    },
+    {
+      "ca_id": 30794,
+      "spell_id": 706033
+    },
+    {
+      "ca_id": 30795,
+      "spell_id": 301266
+    },
+    {
+      "ca_id": 30797,
+      "spell_id": 804629
+    },
+    {
+      "ca_id": 30802,
+      "spell_id": 803128
+    },
+    {
+      "ca_id": 30804,
+      "spell_id": 801938
+    },
+    {
+      "ca_id": 30807,
+      "spell_id": 704212
+    },
+    {
+      "ca_id": 30808,
+      "spell_id": 707416
+    },
+    {
+      "ca_id": 30811,
+      "spell_id": 705141
+    },
+    {
+      "ca_id": 30812,
+      "spell_id": 300323
+    },
+    {
+      "ca_id": 30813,
+      "spell_id": 804630
+    },
+    {
+      "ca_id": 30814,
+      "spell_id": 560123
+    },
+    {
+      "ca_id": 30815,
+      "spell_id": 802161
+    },
+    {
+      "ca_id": 30816,
+      "spell_id": 300334
+    },
+    {
+      "ca_id": 30817,
+      "spell_id": 707077
+    },
+    {
+      "ca_id": 30818,
+      "spell_id": 807874
+    },
+    {
+      "ca_id": 30819,
+      "spell_id": 706628
+    },
+    {
+      "ca_id": 30821,
+      "spell_id": 807960
+    },
+    {
+      "ca_id": 30822,
+      "spell_id": 500329
+    },
+    {
+      "ca_id": 30823,
+      "spell_id": 500950
+    },
+    {
+      "ca_id": 30825,
+      "spell_id": 706636
+    },
+    {
+      "ca_id": 30829,
+      "spell_id": 806140
+    },
+    {
+      "ca_id": 30832,
+      "spell_id": 504380
+    },
+    {
+      "ca_id": 30833,
+      "spell_id": 302888
+    },
+    {
+      "ca_id": 30835,
+      "spell_id": 802990
+    },
+    {
+      "ca_id": 30836,
+      "spell_id": 803159
+    },
+    {
+      "ca_id": 30838,
+      "spell_id": 806155
+    },
+    {
+      "ca_id": 30839,
+      "spell_id": 500236
+    },
+    {
+      "ca_id": 30840,
+      "spell_id": 300347
+    },
+    {
+      "ca_id": 30844,
+      "spell_id": 804452
+    },
+    {
+      "ca_id": 30845,
+      "spell_id": 300280
+    },
+    {
+      "ca_id": 30846,
+      "spell_id": 504292
+    },
+    {
+      "ca_id": 30848,
+      "spell_id": 560535
+    },
+    {
+      "ca_id": 30851,
+      "spell_id": 503655
+    },
+    {
+      "ca_id": 30853,
+      "spell_id": 681097
+    },
+    {
+      "ca_id": 30855,
+      "spell_id": 801277
+    },
+    {
+      "ca_id": 30856,
+      "spell_id": 804435
+    },
+    {
+      "ca_id": 30857,
+      "spell_id": 524856
+    },
+    {
+      "ca_id": 30859,
+      "spell_id": 706121
+    },
+    {
+      "ca_id": 30861,
+      "spell_id": 806216
+    },
+    {
+      "ca_id": 30863,
+      "spell_id": 804969
+    },
+    {
+      "ca_id": 30864,
+      "spell_id": 804602
+    },
+    {
+      "ca_id": 30868,
+      "spell_id": 807233
+    },
+    {
+      "ca_id": 30869,
+      "spell_id": 806224
+    },
+    {
+      "ca_id": 30870,
+      "spell_id": 806228
+    },
+    {
+      "ca_id": 30873,
+      "spell_id": 804652
+    },
+    {
+      "ca_id": 30874,
+      "spell_id": 704370
+    },
+    {
+      "ca_id": 30878,
+      "spell_id": 300595
+    },
+    {
+      "ca_id": 30881,
+      "spell_id": 806222
+    },
+    {
+      "ca_id": 30884,
+      "spell_id": 503696
+    },
+    {
+      "ca_id": 30889,
+      "spell_id": 704505
+    },
+    {
+      "ca_id": 30891,
+      "spell_id": 706538
+    },
+    {
+      "ca_id": 30892,
+      "spell_id": 681222
+    },
+    {
+      "ca_id": 30895,
+      "spell_id": 705894
+    },
+    {
+      "ca_id": 30901,
+      "spell_id": 706096
+    },
+    {
+      "ca_id": 30902,
+      "spell_id": 806727
+    },
+    {
+      "ca_id": 30903,
+      "spell_id": 807036
+    },
+    {
+      "ca_id": 30905,
+      "spell_id": 560310
+    },
+    {
+      "ca_id": 30906,
+      "spell_id": 804591
+    },
+    {
+      "ca_id": 30908,
+      "spell_id": 572722
+    },
+    {
+      "ca_id": 30912,
+      "spell_id": 802132
+    },
+    {
+      "ca_id": 30915,
+      "spell_id": 806086
+    },
+    {
+      "ca_id": 30917,
+      "spell_id": 572130
+    },
+    {
+      "ca_id": 30919,
+      "spell_id": 560537
+    },
+    {
+      "ca_id": 30922,
+      "spell_id": 807309
+    },
+    {
+      "ca_id": 30924,
+      "spell_id": 707534
+    },
+    {
+      "ca_id": 30925,
+      "spell_id": 705071
+    },
+    {
+      "ca_id": 30926,
+      "spell_id": 520615
+    },
+    {
+      "ca_id": 30929,
+      "spell_id": 806342
+    },
+    {
+      "ca_id": 30930,
+      "spell_id": 806360
+    },
+    {
+      "ca_id": 30931,
+      "spell_id": 570737
+    },
+    {
+      "ca_id": 30932,
+      "spell_id": 806368
+    },
+    {
+      "ca_id": 30934,
+      "spell_id": 707542
+    },
+    {
+      "ca_id": 30935,
+      "spell_id": 807877
+    },
+    {
+      "ca_id": 30936,
+      "spell_id": 301258
+    },
+    {
+      "ca_id": 30940,
+      "spell_id": 801855
+    },
+    {
+      "ca_id": 30944,
+      "spell_id": 524954
+    },
+    {
+      "ca_id": 30945,
+      "spell_id": 806407
+    },
+    {
+      "ca_id": 30946,
+      "spell_id": 705723
+    },
+    {
+      "ca_id": 30947,
+      "spell_id": 806409
+    },
+    {
+      "ca_id": 30949,
+      "spell_id": 504196
+    },
+    {
+      "ca_id": 30950,
+      "spell_id": 300957
+    },
+    {
+      "ca_id": 30952,
+      "spell_id": 680716
+    },
+    {
+      "ca_id": 30956,
+      "spell_id": 681066
+    },
+    {
+      "ca_id": 30957,
+      "spell_id": 806060
+    },
+    {
+      "ca_id": 30958,
+      "spell_id": 680634
+    },
+    {
+      "ca_id": 30959,
+      "spell_id": 805496
+    },
+    {
+      "ca_id": 30960,
+      "spell_id": 803158
+    },
+    {
+      "ca_id": 30963,
+      "spell_id": 300514
+    },
+    {
+      "ca_id": 30965,
+      "spell_id": 560648
+    },
+    {
+      "ca_id": 30966,
+      "spell_id": 706138
+    },
+    {
+      "ca_id": 30967,
+      "spell_id": 805445
+    },
+    {
+      "ca_id": 30968,
+      "spell_id": 504732
+    },
+    {
+      "ca_id": 30969,
+      "spell_id": 500937
+    },
+    {
+      "ca_id": 30971,
+      "spell_id": 806552
+    },
+    {
+      "ca_id": 30972,
+      "spell_id": 802595
+    },
+    {
+      "ca_id": 30973,
+      "spell_id": 806563
+    },
+    {
+      "ca_id": 30974,
+      "spell_id": 300682
+    },
+    {
+      "ca_id": 30975,
+      "spell_id": 804977
+    },
+    {
+      "ca_id": 30976,
+      "spell_id": 706877
+    },
+    {
+      "ca_id": 30979,
+      "spell_id": 807500
+    },
+    {
+      "ca_id": 30980,
+      "spell_id": 806631
+    },
+    {
+      "ca_id": 31006,
+      "spell_id": 804068
+    },
+    {
+      "ca_id": 31048,
+      "spell_id": 707670
+    },
+    {
+      "ca_id": 31067,
+      "spell_id": 574328
+    },
+    {
+      "ca_id": 31072,
+      "spell_id": 560111
+    },
+    {
+      "ca_id": 31079,
+      "spell_id": 807336
+    },
+    {
+      "ca_id": 31086,
+      "spell_id": 707232
+    },
+    {
+      "ca_id": 31102,
+      "spell_id": 807842
+    },
+    {
+      "ca_id": 31106,
+      "spell_id": 804557
+    },
+    {
+      "ca_id": 31108,
+      "spell_id": 800758
+    },
+    {
+      "ca_id": 31112,
+      "spell_id": 681001
+    },
+    {
+      "ca_id": 31113,
+      "spell_id": 500241
+    },
+    {
+      "ca_id": 31117,
+      "spell_id": 801955
+    },
+    {
+      "ca_id": 31118,
+      "spell_id": 602220
+    },
+    {
+      "ca_id": 31120,
+      "spell_id": 806753
+    },
+    {
+      "ca_id": 31123,
+      "spell_id": 704880
+    },
+    {
+      "ca_id": 31125,
+      "spell_id": 805203
+    },
+    {
+      "ca_id": 31126,
+      "spell_id": 500118
+    },
+    {
+      "ca_id": 31128,
+      "spell_id": 500476
+    },
+    {
+      "ca_id": 31129,
+      "spell_id": 705556
+    },
+    {
+      "ca_id": 31131,
+      "spell_id": 804550
+    },
+    {
+      "ca_id": 31133,
+      "spell_id": 573060
+    },
+    {
+      "ca_id": 31136,
+      "spell_id": 801511
+    },
+    {
+      "ca_id": 31137,
+      "spell_id": 802219
+    },
+    {
+      "ca_id": 31139,
+      "spell_id": 572771
+    },
+    {
+      "ca_id": 31141,
+      "spell_id": 572821
+    },
+    {
+      "ca_id": 31143,
+      "spell_id": 704729
+    },
+    {
+      "ca_id": 31150,
+      "spell_id": 680700
+    },
+    {
+      "ca_id": 31151,
+      "spell_id": 500915
+    },
+    {
+      "ca_id": 31152,
+      "spell_id": 805832
+    },
+    {
+      "ca_id": 31153,
+      "spell_id": 804729
+    },
+    {
+      "ca_id": 31154,
+      "spell_id": 500015
+    },
+    {
+      "ca_id": 31158,
+      "spell_id": 801895
+    },
+    {
+      "ca_id": 31159,
+      "spell_id": 800206
+    },
+    {
+      "ca_id": 31160,
+      "spell_id": 800165
+    },
+    {
+      "ca_id": 31161,
+      "spell_id": 706260
+    },
+    {
+      "ca_id": 31163,
+      "spell_id": 801847
+    },
+    {
+      "ca_id": 31164,
+      "spell_id": 707615
+    },
+    {
+      "ca_id": 31165,
+      "spell_id": 560020
+    },
+    {
+      "ca_id": 31166,
+      "spell_id": 805555
+    },
+    {
+      "ca_id": 31167,
+      "spell_id": 806965
+    },
+    {
+      "ca_id": 31169,
+      "spell_id": 803129
+    },
+    {
+      "ca_id": 31170,
+      "spell_id": 802286
+    },
+    {
+      "ca_id": 31171,
+      "spell_id": 505344
+    },
+    {
+      "ca_id": 31172,
+      "spell_id": 801446
+    },
+    {
+      "ca_id": 31173,
+      "spell_id": 705293
+    },
+    {
+      "ca_id": 31174,
+      "spell_id": 560650
+    },
+    {
+      "ca_id": 31175,
+      "spell_id": 504728
+    },
+    {
+      "ca_id": 31178,
+      "spell_id": 500075
+    },
+    {
+      "ca_id": 31179,
+      "spell_id": 803851
+    },
+    {
+      "ca_id": 31182,
+      "spell_id": 806296
+    },
+    {
+      "ca_id": 31183,
+      "spell_id": 804503
+    },
+    {
+      "ca_id": 31185,
+      "spell_id": 801760
+    },
+    {
+      "ca_id": 31188,
+      "spell_id": 504750
+    },
+    {
+      "ca_id": 31189,
+      "spell_id": 806250
+    },
+    {
+      "ca_id": 31190,
+      "spell_id": 800446
+    },
+    {
+      "ca_id": 31191,
+      "spell_id": 500714
+    },
+    {
+      "ca_id": 31192,
+      "spell_id": 805503
+    },
+    {
+      "ca_id": 31193,
+      "spell_id": 680813
+    },
+    {
+      "ca_id": 31194,
+      "spell_id": 500146
+    },
+    {
+      "ca_id": 31195,
+      "spell_id": 804247
+    },
+    {
+      "ca_id": 31196,
+      "spell_id": 800626
+    },
+    {
+      "ca_id": 31199,
+      "spell_id": 504527
+    },
+    {
+      "ca_id": 31201,
+      "spell_id": 807600
+    },
+    {
+      "ca_id": 31202,
+      "spell_id": 805094
+    },
+    {
+      "ca_id": 31207,
+      "spell_id": 707367
+    },
+    {
+      "ca_id": 31209,
+      "spell_id": 803973
+    },
+    {
+      "ca_id": 31212,
+      "spell_id": 801087
+    },
+    {
+      "ca_id": 31213,
+      "spell_id": 681093
+    },
+    {
+      "ca_id": 31215,
+      "spell_id": 804858
+    },
+    {
+      "ca_id": 31219,
+      "spell_id": 800132
+    },
+    {
+      "ca_id": 31220,
+      "spell_id": 804731
+    },
+    {
+      "ca_id": 31225,
+      "spell_id": 801202
+    },
+    {
+      "ca_id": 31226,
+      "spell_id": 806273
+    },
+    {
+      "ca_id": 31230,
+      "spell_id": 800141
+    },
+    {
+      "ca_id": 31235,
+      "spell_id": 705806
+    },
+    {
+      "ca_id": 31237,
+      "spell_id": 503550
+    },
+    {
+      "ca_id": 31242,
+      "spell_id": 705577
+    },
+    {
+      "ca_id": 31245,
+      "spell_id": 801945
+    },
+    {
+      "ca_id": 31247,
+      "spell_id": 572800
+    },
+    {
+      "ca_id": 31251,
+      "spell_id": 804223
+    },
+    {
+      "ca_id": 31253,
+      "spell_id": 520442
+    },
+    {
+      "ca_id": 31254,
+      "spell_id": 806516
+    },
+    {
+      "ca_id": 31255,
+      "spell_id": 300502
+    },
+    {
+      "ca_id": 31256,
+      "spell_id": 804897
+    },
+    {
+      "ca_id": 31259,
+      "spell_id": 520290
+    },
+    {
+      "ca_id": 31262,
+      "spell_id": 301986
+    },
+    {
+      "ca_id": 31263,
+      "spell_id": 801838
+    },
+    {
+      "ca_id": 31264,
+      "spell_id": 705700
+    },
+    {
+      "ca_id": 31266,
+      "spell_id": 707719
+    },
+    {
+      "ca_id": 31267,
+      "spell_id": 804036
+    },
+    {
+      "ca_id": 31268,
+      "spell_id": 520087
+    },
+    {
+      "ca_id": 31270,
+      "spell_id": 805743
+    },
+    {
+      "ca_id": 31273,
+      "spell_id": 704278
+    },
+    {
+      "ca_id": 31274,
+      "spell_id": 805552
+    },
+    {
+      "ca_id": 31276,
+      "spell_id": 520149
+    },
+    {
+      "ca_id": 31280,
+      "spell_id": 705054
+    },
+    {
+      "ca_id": 31281,
+      "spell_id": 706284
+    },
+    {
+      "ca_id": 31283,
+      "spell_id": 300706
+    },
+    {
+      "ca_id": 31284,
+      "spell_id": 807493
+    },
+    {
+      "ca_id": 31285,
+      "spell_id": 705341
+    },
+    {
+      "ca_id": 31287,
+      "spell_id": 572784
+    },
+    {
+      "ca_id": 31289,
+      "spell_id": 680337
+    },
+    {
+      "ca_id": 31291,
+      "spell_id": 560836
+    },
+    {
+      "ca_id": 31294,
+      "spell_id": 300465
+    },
+    {
+      "ca_id": 31295,
+      "spell_id": 560284
+    },
+    {
+      "ca_id": 31297,
+      "spell_id": 806103
+    },
+    {
+      "ca_id": 31298,
+      "spell_id": 524950
+    },
+    {
+      "ca_id": 31299,
+      "spell_id": 520805
+    },
+    {
+      "ca_id": 31300,
+      "spell_id": 560645
+    },
+    {
+      "ca_id": 31301,
+      "spell_id": 800188
+    },
+    {
+      "ca_id": 31304,
+      "spell_id": 561222
+    },
+    {
+      "ca_id": 31308,
+      "spell_id": 570158
+    },
+    {
+      "ca_id": 31309,
+      "spell_id": 806143
+    },
+    {
+      "ca_id": 31312,
+      "spell_id": 300929
+    },
+    {
+      "ca_id": 31313,
+      "spell_id": 705271
+    },
+    {
+      "ca_id": 31314,
+      "spell_id": 806153
+    },
+    {
+      "ca_id": 31315,
+      "spell_id": 505200
+    },
+    {
+      "ca_id": 31316,
+      "spell_id": 704420
+    },
+    {
+      "ca_id": 31318,
+      "spell_id": 705332
+    },
+    {
+      "ca_id": 31319,
+      "spell_id": 504383
+    },
+    {
+      "ca_id": 31320,
+      "spell_id": 707137
+    },
+    {
+      "ca_id": 31324,
+      "spell_id": 301183
+    },
+    {
+      "ca_id": 31332,
+      "spell_id": 300873
+    },
+    {
+      "ca_id": 31333,
+      "spell_id": 806209
+    },
+    {
+      "ca_id": 31334,
+      "spell_id": 805854
+    },
+    {
+      "ca_id": 31335,
+      "spell_id": 680808
+    },
+    {
+      "ca_id": 31336,
+      "spell_id": 503831
+    },
+    {
+      "ca_id": 31340,
+      "spell_id": 705902
+    },
+    {
+      "ca_id": 31341,
+      "spell_id": 560278
+    },
+    {
+      "ca_id": 31343,
+      "spell_id": 707405
+    },
+    {
+      "ca_id": 31344,
+      "spell_id": 705877
+    },
+    {
+      "ca_id": 31345,
+      "spell_id": 804620
+    },
+    {
+      "ca_id": 31346,
+      "spell_id": 802092
+    },
+    {
+      "ca_id": 31347,
+      "spell_id": 704495
+    },
+    {
+      "ca_id": 31348,
+      "spell_id": 706551
+    },
+    {
+      "ca_id": 31349,
+      "spell_id": 800330
+    },
+    {
+      "ca_id": 31350,
+      "spell_id": 705910
+    },
+    {
+      "ca_id": 31352,
+      "spell_id": 705323
+    },
+    {
+      "ca_id": 31354,
+      "spell_id": 707310
+    },
+    {
+      "ca_id": 31356,
+      "spell_id": 300305
+    },
+    {
+      "ca_id": 31357,
+      "spell_id": 705047
+    },
+    {
+      "ca_id": 31358,
+      "spell_id": 704524
+    },
+    {
+      "ca_id": 31359,
+      "spell_id": 704533
+    },
+    {
+      "ca_id": 31361,
+      "spell_id": 705318
+    },
+    {
+      "ca_id": 31362,
+      "spell_id": 706333
+    },
+    {
+      "ca_id": 31364,
+      "spell_id": 704535
+    },
+    {
+      "ca_id": 31366,
+      "spell_id": 680996
+    },
+    {
+      "ca_id": 31368,
+      "spell_id": 805198
+    },
+    {
+      "ca_id": 31369,
+      "spell_id": 705413
+    },
+    {
+      "ca_id": 31370,
+      "spell_id": 504560
+    },
+    {
+      "ca_id": 31371,
+      "spell_id": 500373
+    },
+    {
+      "ca_id": 31373,
+      "spell_id": 803995
+    },
+    {
+      "ca_id": 31376,
+      "spell_id": 301256
+    },
+    {
+      "ca_id": 31380,
+      "spell_id": 805628
+    },
+    {
+      "ca_id": 31381,
+      "spell_id": 520024
+    },
+    {
+      "ca_id": 31383,
+      "spell_id": 680670
+    },
+    {
+      "ca_id": 31392,
+      "spell_id": 572889
+    },
+    {
+      "ca_id": 31701,
+      "spell_id": 805669
+    },
+    {
+      "ca_id": 32368,
+      "spell_id": 706878
+    },
+    {
+      "ca_id": 32499,
+      "spell_id": 300759
+    },
+    {
+      "ca_id": 32502,
+      "spell_id": 704947
+    },
+    {
+      "ca_id": 32547,
+      "spell_id": 500115
+    },
+    {
+      "ca_id": 32655,
+      "spell_id": 704343
+    },
+    {
+      "ca_id": 33166,
+      "spell_id": 706318
+    },
+    {
+      "ca_id": 33375,
+      "spell_id": 705636
+    },
+    {
+      "ca_id": 33505,
+      "spell_id": 707320
+    },
+    {
+      "ca_id": 33668,
+      "spell_id": 560573
+    },
+    {
+      "ca_id": 33670,
+      "spell_id": 800352
+    },
+    {
+      "ca_id": 33671,
+      "spell_id": 706266
+    },
+    {
+      "ca_id": 33674,
+      "spell_id": 704607
+    },
+    {
+      "ca_id": 33675,
+      "spell_id": 575335
+    },
+    {
+      "ca_id": 33680,
+      "spell_id": 560479
+    },
+    {
+      "ca_id": 33681,
+      "spell_id": 504290
+    },
+    {
+      "ca_id": 33682,
+      "spell_id": 804201
+    },
+    {
+      "ca_id": 33683,
+      "spell_id": 704626
+    },
+    {
+      "ca_id": 33684,
+      "spell_id": 704625
+    },
+    {
+      "ca_id": 33688,
+      "spell_id": 806310
+    },
+    {
+      "ca_id": 33690,
+      "spell_id": 560261
+    },
+    {
+      "ca_id": 33692,
+      "spell_id": 807544
+    },
+    {
+      "ca_id": 33695,
+      "spell_id": 704636
+    },
+    {
+      "ca_id": 33698,
+      "spell_id": 704646
+    },
+    {
+      "ca_id": 33701,
+      "spell_id": 806210
+    },
+    {
+      "ca_id": 33704,
+      "spell_id": 705732
+    },
+    {
+      "ca_id": 33705,
+      "spell_id": 807491
+    },
+    {
+      "ca_id": 33706,
+      "spell_id": 705731
+    },
+    {
+      "ca_id": 33707,
+      "spell_id": 705733
+    },
+    {
+      "ca_id": 33708,
+      "spell_id": 807345
+    },
+    {
+      "ca_id": 33709,
+      "spell_id": 504254
+    },
+    {
+      "ca_id": 33714,
+      "spell_id": 300260
+    },
+    {
+      "ca_id": 33715,
+      "spell_id": 806177
+    },
+    {
+      "ca_id": 33716,
+      "spell_id": 801960
+    },
+    {
+      "ca_id": 33717,
+      "spell_id": 300982
+    },
+    {
+      "ca_id": 33720,
+      "spell_id": 704670
+    },
+    {
+      "ca_id": 33723,
+      "spell_id": 300958
+    },
+    {
+      "ca_id": 33725,
+      "spell_id": 707006
+    },
+    {
+      "ca_id": 33731,
+      "spell_id": 560620
+    },
+    {
+      "ca_id": 33732,
+      "spell_id": 804371
+    },
+    {
+      "ca_id": 33733,
+      "spell_id": 301333
+    },
+    {
+      "ca_id": 33737,
+      "spell_id": 300986
+    },
+    {
+      "ca_id": 33738,
+      "spell_id": 560848
+    },
+    {
+      "ca_id": 33740,
+      "spell_id": 300580
+    },
+    {
+      "ca_id": 33741,
+      "spell_id": 804851
+    },
+    {
+      "ca_id": 33742,
+      "spell_id": 807488
+    },
+    {
+      "ca_id": 33744,
+      "spell_id": 704690
+    },
+    {
+      "ca_id": 33745,
+      "spell_id": 800490
+    },
+    {
+      "ca_id": 33746,
+      "spell_id": 804686
+    },
+    {
+      "ca_id": 33748,
+      "spell_id": 805048
+    },
+    {
+      "ca_id": 33749,
+      "spell_id": 704701
+    },
+    {
+      "ca_id": 33750,
+      "spell_id": 570136
+    },
+    {
+      "ca_id": 33751,
+      "spell_id": 300233
+    },
+    {
+      "ca_id": 33752,
+      "spell_id": 806328
+    },
+    {
+      "ca_id": 33753,
+      "spell_id": 561353
+    },
+    {
+      "ca_id": 33759,
+      "spell_id": 560798
+    },
+    {
+      "ca_id": 33760,
+      "spell_id": 560800
+    },
+    {
+      "ca_id": 33761,
+      "spell_id": 300941
+    },
+    {
+      "ca_id": 33763,
+      "spell_id": 300236
+    },
+    {
+      "ca_id": 33764,
+      "spell_id": 504050
+    },
+    {
+      "ca_id": 33766,
+      "spell_id": 805674
+    },
+    {
+      "ca_id": 33771,
+      "spell_id": 705750
+    },
+    {
+      "ca_id": 33772,
+      "spell_id": 302519
+    },
+    {
+      "ca_id": 33773,
+      "spell_id": 573426
+    },
+    {
+      "ca_id": 33774,
+      "spell_id": 704682
+    },
+    {
+      "ca_id": 33775,
+      "spell_id": 500971
+    },
+    {
+      "ca_id": 33777,
+      "spell_id": 504861
+    },
+    {
+      "ca_id": 33778,
+      "spell_id": 803741
+    },
+    {
+      "ca_id": 33780,
+      "spell_id": 560622
+    },
+    {
+      "ca_id": 33784,
+      "spell_id": 560615
+    },
+    {
+      "ca_id": 33787,
+      "spell_id": 560896
+    },
+    {
+      "ca_id": 33788,
+      "spell_id": 704769
+    },
+    {
+      "ca_id": 33790,
+      "spell_id": 680812
+    },
+    {
+      "ca_id": 33797,
+      "spell_id": 801143
+    },
+    {
+      "ca_id": 33799,
+      "spell_id": 704785
+    },
+    {
+      "ca_id": 33800,
+      "spell_id": 680805
+    },
+    {
+      "ca_id": 33802,
+      "spell_id": 704771
+    },
+    {
+      "ca_id": 33803,
+      "spell_id": 680223
+    },
+    {
+      "ca_id": 33804,
+      "spell_id": 801975
+    },
+    {
+      "ca_id": 33807,
+      "spell_id": 681521
+    },
+    {
+      "ca_id": 33808,
+      "spell_id": 560956
+    },
+    {
+      "ca_id": 33810,
+      "spell_id": 500608
+    },
+    {
+      "ca_id": 33814,
+      "spell_id": 503779
+    },
+    {
+      "ca_id": 33815,
+      "spell_id": 504001
+    },
+    {
+      "ca_id": 33816,
+      "spell_id": 680809
+    },
+    {
+      "ca_id": 33817,
+      "spell_id": 560539
+    },
+    {
+      "ca_id": 33822,
+      "spell_id": 704764
+    },
+    {
+      "ca_id": 33823,
+      "spell_id": 300262
+    },
+    {
+      "ca_id": 33825,
+      "spell_id": 503583
+    },
+    {
+      "ca_id": 33827,
+      "spell_id": 704765
+    },
+    {
+      "ca_id": 33828,
+      "spell_id": 300256
+    },
+    {
+      "ca_id": 33829,
+      "spell_id": 680789
+    },
+    {
+      "ca_id": 33830,
+      "spell_id": 704775
+    },
+    {
+      "ca_id": 33832,
+      "spell_id": 300259
+    },
+    {
+      "ca_id": 33834,
+      "spell_id": 504694
+    },
+    {
+      "ca_id": 33837,
+      "spell_id": 561206
+    },
+    {
+      "ca_id": 33838,
+      "spell_id": 301236
+    },
+    {
+      "ca_id": 33839,
+      "spell_id": 560721
+    },
+    {
+      "ca_id": 33841,
+      "spell_id": 707636
+    },
+    {
+      "ca_id": 33843,
+      "spell_id": 300921
+    },
+    {
+      "ca_id": 33844,
+      "spell_id": 680709
+    },
+    {
+      "ca_id": 33847,
+      "spell_id": 704784
+    },
+    {
+      "ca_id": 33848,
+      "spell_id": 680779
+    },
+    {
+      "ca_id": 33849,
+      "spell_id": 704786
+    },
+    {
+      "ca_id": 33851,
+      "spell_id": 503639
+    },
+    {
+      "ca_id": 33852,
+      "spell_id": 707635
+    },
+    {
+      "ca_id": 33853,
+      "spell_id": 706575
+    },
+    {
+      "ca_id": 33855,
+      "spell_id": 704794
+    },
+    {
+      "ca_id": 33856,
+      "spell_id": 704788
+    },
+    {
+      "ca_id": 33857,
+      "spell_id": 704792
+    },
+    {
+      "ca_id": 33858,
+      "spell_id": 300992
+    },
+    {
+      "ca_id": 33860,
+      "spell_id": 680705
+    },
+    {
+      "ca_id": 33863,
+      "spell_id": 803452
+    },
+    {
+      "ca_id": 33864,
+      "spell_id": 807319
+    },
+    {
+      "ca_id": 33867,
+      "spell_id": 704809
+    },
+    {
+      "ca_id": 33870,
+      "spell_id": 704813
+    },
+    {
+      "ca_id": 33872,
+      "spell_id": 511109
+    },
+    {
+      "ca_id": 33873,
+      "spell_id": 301974
+    },
+    {
+      "ca_id": 33874,
+      "spell_id": 706238
+    },
+    {
+      "ca_id": 33877,
+      "spell_id": 704823
+    },
+    {
+      "ca_id": 33878,
+      "spell_id": 805468
+    },
+    {
+      "ca_id": 33879,
+      "spell_id": 503804
+    },
+    {
+      "ca_id": 33882,
+      "spell_id": 504397
+    },
+    {
+      "ca_id": 33883,
+      "spell_id": 300975
+    },
+    {
+      "ca_id": 33885,
+      "spell_id": 704273
+    },
+    {
+      "ca_id": 33886,
+      "spell_id": 524877
+    },
+    {
+      "ca_id": 33887,
+      "spell_id": 704884
+    },
+    {
+      "ca_id": 33888,
+      "spell_id": 680607
+    },
+    {
+      "ca_id": 33889,
+      "spell_id": 680377
+    },
+    {
+      "ca_id": 33890,
+      "spell_id": 680557
+    },
+    {
+      "ca_id": 33892,
+      "spell_id": 525019
+    },
+    {
+      "ca_id": 33893,
+      "spell_id": 680569
+    },
+    {
+      "ca_id": 33894,
+      "spell_id": 704869
+    },
+    {
+      "ca_id": 33896,
+      "spell_id": 301182
+    },
+    {
+      "ca_id": 33904,
+      "spell_id": 300970
+    },
+    {
+      "ca_id": 33905,
+      "spell_id": 706862
+    },
+    {
+      "ca_id": 33906,
+      "spell_id": 680836
+    },
+    {
+      "ca_id": 33911,
+      "spell_id": 520381
+    },
+    {
+      "ca_id": 33912,
+      "spell_id": 300932
+    },
+    {
+      "ca_id": 33914,
+      "spell_id": 704864
+    },
+    {
+      "ca_id": 33916,
+      "spell_id": 704851
+    },
+    {
+      "ca_id": 33917,
+      "spell_id": 704863
+    },
+    {
+      "ca_id": 33918,
+      "spell_id": 704862
+    },
+    {
+      "ca_id": 33919,
+      "spell_id": 681145
+    },
+    {
+      "ca_id": 33921,
+      "spell_id": 706464
+    },
+    {
+      "ca_id": 33925,
+      "spell_id": 704434
+    },
+    {
+      "ca_id": 33926,
+      "spell_id": 704476
+    },
+    {
+      "ca_id": 33928,
+      "spell_id": 520682
+    },
+    {
+      "ca_id": 33930,
+      "spell_id": 300264
+    },
+    {
+      "ca_id": 33931,
+      "spell_id": 806266
+    },
+    {
+      "ca_id": 33934,
+      "spell_id": 300287
+    },
+    {
+      "ca_id": 33935,
+      "spell_id": 524887
+    },
+    {
+      "ca_id": 33936,
+      "spell_id": 706911
+    },
+    {
+      "ca_id": 33937,
+      "spell_id": 300296
+    },
+    {
+      "ca_id": 33938,
+      "spell_id": 706917
+    },
+    {
+      "ca_id": 33939,
+      "spell_id": 300300
+    },
+    {
+      "ca_id": 33942,
+      "spell_id": 300304
+    },
+    {
+      "ca_id": 33945,
+      "spell_id": 706722
+    },
+    {
+      "ca_id": 33947,
+      "spell_id": 681102
+    },
+    {
+      "ca_id": 33949,
+      "spell_id": 801539
+    },
+    {
+      "ca_id": 33951,
+      "spell_id": 805110
+    },
+    {
+      "ca_id": 33952,
+      "spell_id": 524879
+    },
+    {
+      "ca_id": 33957,
+      "spell_id": 300298
+    },
+    {
+      "ca_id": 33958,
+      "spell_id": 560446
+    },
+    {
+      "ca_id": 33959,
+      "spell_id": 300308
+    },
+    {
+      "ca_id": 33965,
+      "spell_id": 525065
+    },
+    {
+      "ca_id": 33966,
+      "spell_id": 800105
+    },
+    {
+      "ca_id": 33967,
+      "spell_id": 706177
+    },
+    {
+      "ca_id": 33968,
+      "spell_id": 302015
+    },
+    {
+      "ca_id": 33969,
+      "spell_id": 803283
+    },
+    {
+      "ca_id": 33975,
+      "spell_id": 300290
+    },
+    {
+      "ca_id": 33976,
+      "spell_id": 707640
+    },
+    {
+      "ca_id": 33979,
+      "spell_id": 806479
+    },
+    {
+      "ca_id": 33980,
+      "spell_id": 680622
+    },
+    {
+      "ca_id": 33981,
+      "spell_id": 680630
+    },
+    {
+      "ca_id": 33982,
+      "spell_id": 680619
+    },
+    {
+      "ca_id": 33983,
+      "spell_id": 802935
+    },
+    {
+      "ca_id": 33986,
+      "spell_id": 300325
+    },
+    {
+      "ca_id": 33988,
+      "spell_id": 800764
+    },
+    {
+      "ca_id": 33994,
+      "spell_id": 300341
+    },
+    {
+      "ca_id": 33997,
+      "spell_id": 805629
+    },
+    {
+      "ca_id": 33998,
+      "spell_id": 500147
+    },
+    {
+      "ca_id": 34001,
+      "spell_id": 704565
+    },
+    {
+      "ca_id": 34005,
+      "spell_id": 704938
+    },
+    {
+      "ca_id": 34006,
+      "spell_id": 680637
+    },
+    {
+      "ca_id": 34010,
+      "spell_id": 704562
+    },
+    {
+      "ca_id": 34011,
+      "spell_id": 704586
+    },
+    {
+      "ca_id": 34012,
+      "spell_id": 680631
+    },
+    {
+      "ca_id": 34013,
+      "spell_id": 680643
+    },
+    {
+      "ca_id": 34014,
+      "spell_id": 547214
+    },
+    {
+      "ca_id": 34015,
+      "spell_id": 561327
+    },
+    {
+      "ca_id": 34018,
+      "spell_id": 300322
+    },
+    {
+      "ca_id": 34020,
+      "spell_id": 300367
+    },
+    {
+      "ca_id": 34022,
+      "spell_id": 300371
+    },
+    {
+      "ca_id": 34025,
+      "spell_id": 300331
+    },
+    {
+      "ca_id": 34029,
+      "spell_id": 704909
+    },
+    {
+      "ca_id": 34031,
+      "spell_id": 300314
+    },
+    {
+      "ca_id": 34032,
+      "spell_id": 704581
+    },
+    {
+      "ca_id": 34035,
+      "spell_id": 800602
+    },
+    {
+      "ca_id": 34037,
+      "spell_id": 704568
+    },
+    {
+      "ca_id": 34038,
+      "spell_id": 582832
+    },
+    {
+      "ca_id": 34039,
+      "spell_id": 300351
+    },
+    {
+      "ca_id": 34041,
+      "spell_id": 806123
+    },
+    {
+      "ca_id": 34042,
+      "spell_id": 704920
+    },
+    {
+      "ca_id": 34043,
+      "spell_id": 300357
+    },
+    {
+      "ca_id": 34046,
+      "spell_id": 300360
+    },
+    {
+      "ca_id": 34049,
+      "spell_id": 807964
+    },
+    {
+      "ca_id": 34050,
+      "spell_id": 806021
+    },
+    {
+      "ca_id": 34051,
+      "spell_id": 804625
+    },
+    {
+      "ca_id": 34052,
+      "spell_id": 704908
+    },
+    {
+      "ca_id": 34053,
+      "spell_id": 504734
+    },
+    {
+      "ca_id": 34056,
+      "spell_id": 704979
+    },
+    {
+      "ca_id": 34058,
+      "spell_id": 560633
+    },
+    {
+      "ca_id": 34059,
+      "spell_id": 704954
+    },
+    {
+      "ca_id": 34060,
+      "spell_id": 302581
+    },
+    {
+      "ca_id": 34061,
+      "spell_id": 520008
+    },
+    {
+      "ca_id": 34063,
+      "spell_id": 707515
+    },
+    {
+      "ca_id": 34064,
+      "spell_id": 300395
+    },
+    {
+      "ca_id": 34066,
+      "spell_id": 805696
+    },
+    {
+      "ca_id": 34067,
+      "spell_id": 805706
+    },
+    {
+      "ca_id": 34068,
+      "spell_id": 301358
+    },
+    {
+      "ca_id": 34069,
+      "spell_id": 300376
+    },
+    {
+      "ca_id": 34071,
+      "spell_id": 705018
+    },
+    {
+      "ca_id": 34074,
+      "spell_id": 300384
+    },
+    {
+      "ca_id": 34075,
+      "spell_id": 706566
+    },
+    {
+      "ca_id": 34076,
+      "spell_id": 300386
+    },
+    {
+      "ca_id": 34077,
+      "spell_id": 706565
+    },
+    {
+      "ca_id": 34079,
+      "spell_id": 704973
+    },
+    {
+      "ca_id": 34085,
+      "spell_id": 706755
+    },
+    {
+      "ca_id": 34086,
+      "spell_id": 704972
+    },
+    {
+      "ca_id": 34087,
+      "spell_id": 704971
+    },
+    {
+      "ca_id": 34090,
+      "spell_id": 704956
+    },
+    {
+      "ca_id": 34091,
+      "spell_id": 704182
+    },
+    {
+      "ca_id": 34094,
+      "spell_id": 704987
+    },
+    {
+      "ca_id": 34096,
+      "spell_id": 680216
+    },
+    {
+      "ca_id": 34097,
+      "spell_id": 560828
+    },
+    {
+      "ca_id": 34098,
+      "spell_id": 300963
+    },
+    {
+      "ca_id": 34099,
+      "spell_id": 704989
+    },
+    {
+      "ca_id": 34100,
+      "spell_id": 802342
+    },
+    {
+      "ca_id": 34104,
+      "spell_id": 680991
+    },
+    {
+      "ca_id": 34105,
+      "spell_id": 805697
+    },
+    {
+      "ca_id": 34107,
+      "spell_id": 807669
+    },
+    {
+      "ca_id": 34108,
+      "spell_id": 802602
+    },
+    {
+      "ca_id": 34109,
+      "spell_id": 680900
+    },
+    {
+      "ca_id": 34110,
+      "spell_id": 705000
+    },
+    {
+      "ca_id": 34111,
+      "spell_id": 300393
+    },
+    {
+      "ca_id": 34112,
+      "spell_id": 520295
+    },
+    {
+      "ca_id": 34114,
+      "spell_id": 706590
+    },
+    {
+      "ca_id": 34117,
+      "spell_id": 704980
+    },
+    {
+      "ca_id": 34119,
+      "spell_id": 704186
+    },
+    {
+      "ca_id": 34120,
+      "spell_id": 800702
+    },
+    {
+      "ca_id": 34125,
+      "spell_id": 705016
+    },
+    {
+      "ca_id": 34127,
+      "spell_id": 805695
+    },
+    {
+      "ca_id": 34132,
+      "spell_id": 524897
+    },
+    {
+      "ca_id": 34133,
+      "spell_id": 804178
+    },
+    {
+      "ca_id": 34136,
+      "spell_id": 520227
+    },
+    {
+      "ca_id": 34137,
+      "spell_id": 800358
+    },
+    {
+      "ca_id": 34139,
+      "spell_id": 801438
+    },
+    {
+      "ca_id": 34140,
+      "spell_id": 705061
+    },
+    {
+      "ca_id": 34141,
+      "spell_id": 561110
+    },
+    {
+      "ca_id": 34147,
+      "spell_id": 560802
+    },
+    {
+      "ca_id": 34148,
+      "spell_id": 500071
+    },
+    {
+      "ca_id": 34151,
+      "spell_id": 705032
+    },
+    {
+      "ca_id": 34152,
+      "spell_id": 704312
+    },
+    {
+      "ca_id": 34153,
+      "spell_id": 707888
+    },
+    {
+      "ca_id": 34155,
+      "spell_id": 301249
+    },
+    {
+      "ca_id": 34156,
+      "spell_id": 560341
+    },
+    {
+      "ca_id": 34157,
+      "spell_id": 801468
+    },
+    {
+      "ca_id": 34159,
+      "spell_id": 707417
+    },
+    {
+      "ca_id": 34164,
+      "spell_id": 705087
+    },
+    {
+      "ca_id": 34166,
+      "spell_id": 807668
+    },
+    {
+      "ca_id": 34167,
+      "spell_id": 806973
+    },
+    {
+      "ca_id": 34168,
+      "spell_id": 705026
+    },
+    {
+      "ca_id": 34169,
+      "spell_id": 804027
+    },
+    {
+      "ca_id": 34171,
+      "spell_id": 504008
+    },
+    {
+      "ca_id": 34172,
+      "spell_id": 800359
+    },
+    {
+      "ca_id": 34175,
+      "spell_id": 560344
+    },
+    {
+      "ca_id": 34176,
+      "spell_id": 524654
+    },
+    {
+      "ca_id": 34179,
+      "spell_id": 705074
+    },
+    {
+      "ca_id": 34180,
+      "spell_id": 560805
+    },
+    {
+      "ca_id": 34181,
+      "spell_id": 804715
+    },
+    {
+      "ca_id": 34182,
+      "spell_id": 520621
+    },
+    {
+      "ca_id": 34184,
+      "spell_id": 800685
+    },
+    {
+      "ca_id": 34185,
+      "spell_id": 800150
+    },
+    {
+      "ca_id": 34188,
+      "spell_id": 803115
+    },
+    {
+      "ca_id": 34192,
+      "spell_id": 573043
+    },
+    {
+      "ca_id": 34195,
+      "spell_id": 705075
+    },
+    {
+      "ca_id": 34196,
+      "spell_id": 705072
+    },
+    {
+      "ca_id": 34199,
+      "spell_id": 573056
+    },
+    {
+      "ca_id": 34201,
+      "spell_id": 706282
+    },
+    {
+      "ca_id": 34203,
+      "spell_id": 705108
+    },
+    {
+      "ca_id": 34204,
+      "spell_id": 705125
+    },
+    {
+      "ca_id": 34205,
+      "spell_id": 704374
+    },
+    {
+      "ca_id": 34207,
+      "spell_id": 705102
+    },
+    {
+      "ca_id": 34209,
+      "spell_id": 560542
+    },
+    {
+      "ca_id": 34211,
+      "spell_id": 704606
+    },
+    {
+      "ca_id": 34212,
+      "spell_id": 301287
+    },
+    {
+      "ca_id": 34213,
+      "spell_id": 520257
+    },
+    {
+      "ca_id": 34217,
+      "spell_id": 805245
+    },
+    {
+      "ca_id": 34219,
+      "spell_id": 705122
+    },
+    {
+      "ca_id": 34220,
+      "spell_id": 805256
+    },
+    {
+      "ca_id": 34221,
+      "spell_id": 300466
+    },
+    {
+      "ca_id": 34222,
+      "spell_id": 803478
+    },
+    {
+      "ca_id": 34224,
+      "spell_id": 805243
+    },
+    {
+      "ca_id": 34226,
+      "spell_id": 520885
+    },
+    {
+      "ca_id": 34227,
+      "spell_id": 804609
+    },
+    {
+      "ca_id": 34228,
+      "spell_id": 805236
+    },
+    {
+      "ca_id": 34229,
+      "spell_id": 300476
+    },
+    {
+      "ca_id": 34230,
+      "spell_id": 800203
+    },
+    {
+      "ca_id": 34231,
+      "spell_id": 560533
+    },
+    {
+      "ca_id": 34232,
+      "spell_id": 800214
+    },
+    {
+      "ca_id": 34234,
+      "spell_id": 300477
+    },
+    {
+      "ca_id": 34236,
+      "spell_id": 801892
+    },
+    {
+      "ca_id": 34237,
+      "spell_id": 300489
+    },
+    {
+      "ca_id": 34238,
+      "spell_id": 300484
+    },
+    {
+      "ca_id": 34243,
+      "spell_id": 801904
+    },
+    {
+      "ca_id": 34244,
+      "spell_id": 555738
+    },
+    {
+      "ca_id": 34245,
+      "spell_id": 806111
+    },
+    {
+      "ca_id": 34249,
+      "spell_id": 705135
+    },
+    {
+      "ca_id": 34251,
+      "spell_id": 560578
+    },
+    {
+      "ca_id": 34252,
+      "spell_id": 707907
+    },
+    {
+      "ca_id": 34256,
+      "spell_id": 560637
+    },
+    {
+      "ca_id": 34257,
+      "spell_id": 705162
+    },
+    {
+      "ca_id": 34258,
+      "spell_id": 705158
+    },
+    {
+      "ca_id": 34259,
+      "spell_id": 705152
+    },
+    {
+      "ca_id": 34260,
+      "spell_id": 706821
+    },
+    {
+      "ca_id": 34261,
+      "spell_id": 705168
+    },
+    {
+      "ca_id": 34262,
+      "spell_id": 705216
+    },
+    {
+      "ca_id": 34263,
+      "spell_id": 705218
+    },
+    {
+      "ca_id": 34264,
+      "spell_id": 705214
+    },
+    {
+      "ca_id": 34265,
+      "spell_id": 807047
+    },
+    {
+      "ca_id": 34266,
+      "spell_id": 803085
+    },
+    {
+      "ca_id": 34268,
+      "spell_id": 500913
+    },
+    {
+      "ca_id": 34271,
+      "spell_id": 561326
+    },
+    {
+      "ca_id": 34274,
+      "spell_id": 706653
+    },
+    {
+      "ca_id": 34275,
+      "spell_id": 707410
+    },
+    {
+      "ca_id": 34276,
+      "spell_id": 561322
+    },
+    {
+      "ca_id": 34277,
+      "spell_id": 560886
+    },
+    {
+      "ca_id": 34279,
+      "spell_id": 560456
+    },
+    {
+      "ca_id": 34291,
+      "spell_id": 705169
+    },
+    {
+      "ca_id": 34293,
+      "spell_id": 560205
+    },
+    {
+      "ca_id": 34295,
+      "spell_id": 707721
+    },
+    {
+      "ca_id": 34299,
+      "spell_id": 804746
+    },
+    {
+      "ca_id": 34302,
+      "spell_id": 705171
+    },
+    {
+      "ca_id": 34303,
+      "spell_id": 805821
+    },
+    {
+      "ca_id": 34304,
+      "spell_id": 681060
+    },
+    {
+      "ca_id": 34305,
+      "spell_id": 572799
+    },
+    {
+      "ca_id": 34306,
+      "spell_id": 800838
+    },
+    {
+      "ca_id": 34307,
+      "spell_id": 705221
+    },
+    {
+      "ca_id": 34309,
+      "spell_id": 705153
+    },
+    {
+      "ca_id": 34311,
+      "spell_id": 705208
+    },
+    {
+      "ca_id": 34312,
+      "spell_id": 804768
+    },
+    {
+      "ca_id": 34313,
+      "spell_id": 681063
+    },
+    {
+      "ca_id": 34314,
+      "spell_id": 704240
+    },
+    {
+      "ca_id": 34319,
+      "spell_id": 560881
+    },
+    {
+      "ca_id": 34320,
+      "spell_id": 705206
+    },
+    {
+      "ca_id": 34321,
+      "spell_id": 705232
+    },
+    {
+      "ca_id": 34325,
+      "spell_id": 500060
+    },
+    {
+      "ca_id": 34326,
+      "spell_id": 300879
+    },
+    {
+      "ca_id": 34329,
+      "spell_id": 560517
+    },
+    {
+      "ca_id": 34334,
+      "spell_id": 706320
+    },
+    {
+      "ca_id": 34335,
+      "spell_id": 705290
+    },
+    {
+      "ca_id": 34337,
+      "spell_id": 707385
+    },
+    {
+      "ca_id": 34338,
+      "spell_id": 705250
+    },
+    {
+      "ca_id": 34339,
+      "spell_id": 705276
+    },
+    {
+      "ca_id": 34340,
+      "spell_id": 801461
+    },
+    {
+      "ca_id": 34341,
+      "spell_id": 707754
+    },
+    {
+      "ca_id": 34342,
+      "spell_id": 706323
+    },
+    {
+      "ca_id": 34343,
+      "spell_id": 680891
+    },
+    {
+      "ca_id": 34345,
+      "spell_id": 681009
+    },
+    {
+      "ca_id": 34346,
+      "spell_id": 500694
+    },
+    {
+      "ca_id": 34347,
+      "spell_id": 524767
+    },
+    {
+      "ca_id": 34348,
+      "spell_id": 705263
+    },
+    {
+      "ca_id": 34349,
+      "spell_id": 705268
+    },
+    {
+      "ca_id": 34350,
+      "spell_id": 705306
+    },
+    {
+      "ca_id": 34352,
+      "spell_id": 801465
+    },
+    {
+      "ca_id": 34353,
+      "spell_id": 1397742
+    },
+    {
+      "ca_id": 34355,
+      "spell_id": 705283
+    },
+    {
+      "ca_id": 34356,
+      "spell_id": 524747
+    },
+    {
+      "ca_id": 34357,
+      "spell_id": 525024
+    },
+    {
+      "ca_id": 34358,
+      "spell_id": 704116
+    },
+    {
+      "ca_id": 34359,
+      "spell_id": 523712
+    },
+    {
+      "ca_id": 34361,
+      "spell_id": 300504
+    },
+    {
+      "ca_id": 34366,
+      "spell_id": 300607
+    },
+    {
+      "ca_id": 34368,
+      "spell_id": 705287
+    },
+    {
+      "ca_id": 34369,
+      "spell_id": 705255
+    },
+    {
+      "ca_id": 34371,
+      "spell_id": 300524
+    },
+    {
+      "ca_id": 34372,
+      "spell_id": 805409
+    },
+    {
+      "ca_id": 34373,
+      "spell_id": 707391
+    },
+    {
+      "ca_id": 34375,
+      "spell_id": 801457
+    },
+    {
+      "ca_id": 34377,
+      "spell_id": 706359
+    },
+    {
+      "ca_id": 34379,
+      "spell_id": 705278
+    },
+    {
+      "ca_id": 34381,
+      "spell_id": 706312
+    },
+    {
+      "ca_id": 34382,
+      "spell_id": 705272
+    },
+    {
+      "ca_id": 34384,
+      "spell_id": 706325
+    },
+    {
+      "ca_id": 34385,
+      "spell_id": 301309
+    },
+    {
+      "ca_id": 34386,
+      "spell_id": 800424
+    },
+    {
+      "ca_id": 34390,
+      "spell_id": 560835
+    },
+    {
+      "ca_id": 34391,
+      "spell_id": 712677
+    },
+    {
+      "ca_id": 34392,
+      "spell_id": 301059
+    },
+    {
+      "ca_id": 34395,
+      "spell_id": 301311
+    },
+    {
+      "ca_id": 34396,
+      "spell_id": 706385
+    },
+    {
+      "ca_id": 34397,
+      "spell_id": 705259
+    },
+    {
+      "ca_id": 34398,
+      "spell_id": 680399
+    },
+    {
+      "ca_id": 34399,
+      "spell_id": 805420
+    },
+    {
+      "ca_id": 34400,
+      "spell_id": 705298
+    },
+    {
+      "ca_id": 34402,
+      "spell_id": 500678
+    },
+    {
+      "ca_id": 34403,
+      "spell_id": 801219
+    },
+    {
+      "ca_id": 34404,
+      "spell_id": 705315
+    },
+    {
+      "ca_id": 34405,
+      "spell_id": 807346
+    },
+    {
+      "ca_id": 34407,
+      "spell_id": 705324
+    },
+    {
+      "ca_id": 34410,
+      "spell_id": 504184
+    },
+    {
+      "ca_id": 34414,
+      "spell_id": 300534
+    },
+    {
+      "ca_id": 34415,
+      "spell_id": 503532
+    },
+    {
+      "ca_id": 34417,
+      "spell_id": 804383
+    },
+    {
+      "ca_id": 34419,
+      "spell_id": 705378
+    },
+    {
+      "ca_id": 34421,
+      "spell_id": 705316
+    },
+    {
+      "ca_id": 34422,
+      "spell_id": 706336
+    },
+    {
+      "ca_id": 34425,
+      "spell_id": 705343
+    },
+    {
+      "ca_id": 34426,
+      "spell_id": 802870
+    },
+    {
+      "ca_id": 34427,
+      "spell_id": 706639
+    },
+    {
+      "ca_id": 34429,
+      "spell_id": 705377
+    },
+    {
+      "ca_id": 34430,
+      "spell_id": 803963
+    },
+    {
+      "ca_id": 34433,
+      "spell_id": 300540
+    },
+    {
+      "ca_id": 34434,
+      "spell_id": 505199
+    },
+    {
+      "ca_id": 34435,
+      "spell_id": 705351
+    },
+    {
+      "ca_id": 34436,
+      "spell_id": 503631
+    },
+    {
+      "ca_id": 34438,
+      "spell_id": 704413
+    },
+    {
+      "ca_id": 34439,
+      "spell_id": 803830
+    },
+    {
+      "ca_id": 34440,
+      "spell_id": 705379
+    },
+    {
+      "ca_id": 34441,
+      "spell_id": 705345
+    },
+    {
+      "ca_id": 34443,
+      "spell_id": 705333
+    },
+    {
+      "ca_id": 34445,
+      "spell_id": 704418
+    },
+    {
+      "ca_id": 34446,
+      "spell_id": 524932
+    },
+    {
+      "ca_id": 34447,
+      "spell_id": 803134
+    },
+    {
+      "ca_id": 34448,
+      "spell_id": 705369
+    },
+    {
+      "ca_id": 34450,
+      "spell_id": 301057
+    },
+    {
+      "ca_id": 34451,
+      "spell_id": 300534
+    },
+    {
+      "ca_id": 34453,
+      "spell_id": 300536
+    },
+    {
+      "ca_id": 34455,
+      "spell_id": 705336
+    },
+    {
+      "ca_id": 34458,
+      "spell_id": 802295
+    },
+    {
+      "ca_id": 34460,
+      "spell_id": 301193
+    },
+    {
+      "ca_id": 34461,
+      "spell_id": 561100
+    },
+    {
+      "ca_id": 34464,
+      "spell_id": 705397
+    },
+    {
+      "ca_id": 34465,
+      "spell_id": 705401
+    },
+    {
+      "ca_id": 34466,
+      "spell_id": 560917
+    },
+    {
+      "ca_id": 34469,
+      "spell_id": 807419
+    },
+    {
+      "ca_id": 34470,
+      "spell_id": 705392
+    },
+    {
+      "ca_id": 34472,
+      "spell_id": 705442
+    },
+    {
+      "ca_id": 34473,
+      "spell_id": 560919
+    },
+    {
+      "ca_id": 34474,
+      "spell_id": 705406
+    },
+    {
+      "ca_id": 34476,
+      "spell_id": 705416
+    },
+    {
+      "ca_id": 34477,
+      "spell_id": 572879
+    },
+    {
+      "ca_id": 34480,
+      "spell_id": 504011
+    },
+    {
+      "ca_id": 34481,
+      "spell_id": 504037
+    },
+    {
+      "ca_id": 34489,
+      "spell_id": 804671
+    },
+    {
+      "ca_id": 34492,
+      "spell_id": 805192
+    },
+    {
+      "ca_id": 34495,
+      "spell_id": 573071
+    },
+    {
+      "ca_id": 34497,
+      "spell_id": 300553
+    },
+    {
+      "ca_id": 34499,
+      "spell_id": 805184
+    },
+    {
+      "ca_id": 34500,
+      "spell_id": 560412
+    },
+    {
+      "ca_id": 34502,
+      "spell_id": 504012
+    },
+    {
+      "ca_id": 34505,
+      "spell_id": 805188
+    },
+    {
+      "ca_id": 34507,
+      "spell_id": 560927
+    },
+    {
+      "ca_id": 34510,
+      "spell_id": 560419
+    },
+    {
+      "ca_id": 34515,
+      "spell_id": 706795
+    },
+    {
+      "ca_id": 34516,
+      "spell_id": 705404
+    },
+    {
+      "ca_id": 34520,
+      "spell_id": 560478
+    },
+    {
+      "ca_id": 34521,
+      "spell_id": 300565
+    },
+    {
+      "ca_id": 34524,
+      "spell_id": 570726
+    },
+    {
+      "ca_id": 34527,
+      "spell_id": 804187
+    },
+    {
+      "ca_id": 34528,
+      "spell_id": 503669
+    },
+    {
+      "ca_id": 34530,
+      "spell_id": 524854
+    },
+    {
+      "ca_id": 34531,
+      "spell_id": 705463
+    },
+    {
+      "ca_id": 34532,
+      "spell_id": 574149
+    },
+    {
+      "ca_id": 34538,
+      "spell_id": 300792
+    },
+    {
+      "ca_id": 34540,
+      "spell_id": 705465
+    },
+    {
+      "ca_id": 34541,
+      "spell_id": 705484
+    },
+    {
+      "ca_id": 34544,
+      "spell_id": 705480
+    },
+    {
+      "ca_id": 34545,
+      "spell_id": 805365
+    },
+    {
+      "ca_id": 34546,
+      "spell_id": 680542
+    },
+    {
+      "ca_id": 34547,
+      "spell_id": 300571
+    },
+    {
+      "ca_id": 34550,
+      "spell_id": 681329
+    },
+    {
+      "ca_id": 34555,
+      "spell_id": 806195
+    },
+    {
+      "ca_id": 34556,
+      "spell_id": 705498
+    },
+    {
+      "ca_id": 34557,
+      "spell_id": 804024
+    },
+    {
+      "ca_id": 34558,
+      "spell_id": 705528
+    },
+    {
+      "ca_id": 34560,
+      "spell_id": 681152
+    },
+    {
+      "ca_id": 34561,
+      "spell_id": 705499
+    },
+    {
+      "ca_id": 34564,
+      "spell_id": 680384
+    },
+    {
+      "ca_id": 34570,
+      "spell_id": 503682
+    },
+    {
+      "ca_id": 34572,
+      "spell_id": 680322
+    },
+    {
+      "ca_id": 34573,
+      "spell_id": 520593
+    },
+    {
+      "ca_id": 34576,
+      "spell_id": 300578
+    },
+    {
+      "ca_id": 34578,
+      "spell_id": 300581
+    },
+    {
+      "ca_id": 34579,
+      "spell_id": 560540
+    },
+    {
+      "ca_id": 34580,
+      "spell_id": 705621
+    },
+    {
+      "ca_id": 34581,
+      "spell_id": 706823
+    },
+    {
+      "ca_id": 34583,
+      "spell_id": 503698
+    },
+    {
+      "ca_id": 34587,
+      "spell_id": 705526
+    },
+    {
+      "ca_id": 34588,
+      "spell_id": 501380
+    },
+    {
+      "ca_id": 34592,
+      "spell_id": 789256
+    },
+    {
+      "ca_id": 34593,
+      "spell_id": 707230
+    },
+    {
+      "ca_id": 34595,
+      "spell_id": 705534
+    },
+    {
+      "ca_id": 34598,
+      "spell_id": 707150
+    },
+    {
+      "ca_id": 34599,
+      "spell_id": 645435
+    },
+    {
+      "ca_id": 34601,
+      "spell_id": 806704
+    },
+    {
+      "ca_id": 34602,
+      "spell_id": 520138
+    },
+    {
+      "ca_id": 34603,
+      "spell_id": 805724
+    },
+    {
+      "ca_id": 34605,
+      "spell_id": 705627
+    },
+    {
+      "ca_id": 34607,
+      "spell_id": 706674
+    },
+    {
+      "ca_id": 34609,
+      "spell_id": 804531
+    },
+    {
+      "ca_id": 34610,
+      "spell_id": 804232
+    },
+    {
+      "ca_id": 34612,
+      "spell_id": 520237
+    },
+    {
+      "ca_id": 34614,
+      "spell_id": 520054
+    },
+    {
+      "ca_id": 34615,
+      "spell_id": 705563
+    },
+    {
+      "ca_id": 34616,
+      "spell_id": 707413
+    },
+    {
+      "ca_id": 34617,
+      "spell_id": 705583
+    },
+    {
+      "ca_id": 34619,
+      "spell_id": 706518
+    },
+    {
+      "ca_id": 34621,
+      "spell_id": 705600
+    },
+    {
+      "ca_id": 34622,
+      "spell_id": 706670
+    },
+    {
+      "ca_id": 34624,
+      "spell_id": 705580
+    },
+    {
+      "ca_id": 34628,
+      "spell_id": 705742
+    },
+    {
+      "ca_id": 34633,
+      "spell_id": 801962
+    },
+    {
+      "ca_id": 34635,
+      "spell_id": 300593
+    },
+    {
+      "ca_id": 34638,
+      "spell_id": 567542
+    },
+    {
+      "ca_id": 34640,
+      "spell_id": 806737
+    },
+    {
+      "ca_id": 34641,
+      "spell_id": 300597
+    },
+    {
+      "ca_id": 34646,
+      "spell_id": 707204
+    },
+    {
+      "ca_id": 34647,
+      "spell_id": 707149
+    },
+    {
+      "ca_id": 34648,
+      "spell_id": 806795
+    },
+    {
+      "ca_id": 34649,
+      "spell_id": 560992
+    },
+    {
+      "ca_id": 34650,
+      "spell_id": 567533
+    },
+    {
+      "ca_id": 34653,
+      "spell_id": 500671
+    },
+    {
+      "ca_id": 34655,
+      "spell_id": 520524
+    },
+    {
+      "ca_id": 34656,
+      "spell_id": 806708
+    },
+    {
+      "ca_id": 34659,
+      "spell_id": 560050
+    },
+    {
+      "ca_id": 34660,
+      "spell_id": 560053
+    },
+    {
+      "ca_id": 34661,
+      "spell_id": 705543
+    },
+    {
+      "ca_id": 34663,
+      "spell_id": 705554
+    },
+    {
+      "ca_id": 34664,
+      "spell_id": 705625
+    },
+    {
+      "ca_id": 34665,
+      "spell_id": 300576
+    },
+    {
+      "ca_id": 34668,
+      "spell_id": 802204
+    },
+    {
+      "ca_id": 34669,
+      "spell_id": 520099
+    },
+    {
+      "ca_id": 34670,
+      "spell_id": 520015
+    },
+    {
+      "ca_id": 34673,
+      "spell_id": 300606
+    },
+    {
+      "ca_id": 34674,
+      "spell_id": 705667
+    },
+    {
+      "ca_id": 34676,
+      "spell_id": 567555
+    },
+    {
+      "ca_id": 34679,
+      "spell_id": 706660
+    },
+    {
+      "ca_id": 34684,
+      "spell_id": 801859
+    },
+    {
+      "ca_id": 34685,
+      "spell_id": 807196
+    },
+    {
+      "ca_id": 34686,
+      "spell_id": 705727
+    },
+    {
+      "ca_id": 34687,
+      "spell_id": 705645
+    },
+    {
+      "ca_id": 34690,
+      "spell_id": 806412
+    },
+    {
+      "ca_id": 34691,
+      "spell_id": 705653
+    },
+    {
+      "ca_id": 34692,
+      "spell_id": 570173
+    },
+    {
+      "ca_id": 34693,
+      "spell_id": 300618
+    },
+    {
+      "ca_id": 34694,
+      "spell_id": 705675
+    },
+    {
+      "ca_id": 34695,
+      "spell_id": 705652
+    },
+    {
+      "ca_id": 34696,
+      "spell_id": 804828
+    },
+    {
+      "ca_id": 34911,
+      "spell_id": 707054
+    },
+    {
+      "ca_id": 34912,
+      "spell_id": 300612
+    },
+    {
+      "ca_id": 34914,
+      "spell_id": 804035
+    },
+    {
+      "ca_id": 34915,
+      "spell_id": 806100
+    },
+    {
+      "ca_id": 34916,
+      "spell_id": 807462
+    },
+    {
+      "ca_id": 34917,
+      "spell_id": 301219
+    },
+    {
+      "ca_id": 34918,
+      "spell_id": 300611
+    },
+    {
+      "ca_id": 34919,
+      "spell_id": 707053
+    },
+    {
+      "ca_id": 34920,
+      "spell_id": 300596
+    },
+    {
+      "ca_id": 34922,
+      "spell_id": 705672
+    },
+    {
+      "ca_id": 34924,
+      "spell_id": 503596
+    },
+    {
+      "ca_id": 34926,
+      "spell_id": 705689
+    },
+    {
+      "ca_id": 34930,
+      "spell_id": 807314
+    },
+    {
+      "ca_id": 34931,
+      "spell_id": 705690
+    },
+    {
+      "ca_id": 34935,
+      "spell_id": 705720
+    },
+    {
+      "ca_id": 34937,
+      "spell_id": 300610
+    },
+    {
+      "ca_id": 34938,
+      "spell_id": 705693
+    },
+    {
+      "ca_id": 34940,
+      "spell_id": 706629
+    },
+    {
+      "ca_id": 34941,
+      "spell_id": 705702
+    },
+    {
+      "ca_id": 34943,
+      "spell_id": 705686
+    },
+    {
+      "ca_id": 34948,
+      "spell_id": 570128
+    },
+    {
+      "ca_id": 34949,
+      "spell_id": 300827
+    },
+    {
+      "ca_id": 34951,
+      "spell_id": 704222
+    },
+    {
+      "ca_id": 34955,
+      "spell_id": 705719
+    },
+    {
+      "ca_id": 34956,
+      "spell_id": 705659
+    },
+    {
+      "ca_id": 34957,
+      "spell_id": 300839
+    },
+    {
+      "ca_id": 34958,
+      "spell_id": 800098
+    },
+    {
+      "ca_id": 34960,
+      "spell_id": 300616
+    },
+    {
+      "ca_id": 34963,
+      "spell_id": 706656
+    },
+    {
+      "ca_id": 34964,
+      "spell_id": 300590
+    },
+    {
+      "ca_id": 34965,
+      "spell_id": 504098
+    },
+    {
+      "ca_id": 34966,
+      "spell_id": 705734
+    },
+    {
+      "ca_id": 34969,
+      "spell_id": 504263
+    },
+    {
+      "ca_id": 34974,
+      "spell_id": 800154
+    },
+    {
+      "ca_id": 34976,
+      "spell_id": 524687
+    },
+    {
+      "ca_id": 34977,
+      "spell_id": 560613
+    },
+    {
+      "ca_id": 34978,
+      "spell_id": 300240
+    },
+    {
+      "ca_id": 34980,
+      "spell_id": 803772
+    },
+    {
+      "ca_id": 34981,
+      "spell_id": 704721
+    },
+    {
+      "ca_id": 34982,
+      "spell_id": 705754
+    },
+    {
+      "ca_id": 34984,
+      "spell_id": 300636
+    },
+    {
+      "ca_id": 34985,
+      "spell_id": 707253
+    },
+    {
+      "ca_id": 34987,
+      "spell_id": 706695
+    },
+    {
+      "ca_id": 34989,
+      "spell_id": 707252
+    },
+    {
+      "ca_id": 34992,
+      "spell_id": 706379
+    },
+    {
+      "ca_id": 34994,
+      "spell_id": 707260
+    },
+    {
+      "ca_id": 34996,
+      "spell_id": 707269
+    },
+    {
+      "ca_id": 34997,
+      "spell_id": 707258
+    },
+    {
+      "ca_id": 35000,
+      "spell_id": 705796
+    },
+    {
+      "ca_id": 66733,
+      "spell_id": 801179
+    },
+    {
+      "ca_id": 72356,
+      "spell_id": 504848
+    }
+  ],
+  "master_absent_ids": [
+    46565,
+    300350,
+    300684,
+    301301,
+    430870,
+    500000,
+    500002,
+    500005,
+    500007,
+    500008,
+    500009,
+    500010,
+    500016,
+    500018,
+    500022,
+    500024,
+    500045,
+    500049,
+    500050,
+    500051,
+    500052,
+    500054,
+    500058,
+    500059,
+    500061,
+    500063,
+    500066,
+    500068,
+    500070,
+    500073,
+    500074,
+    500083,
+    500089,
+    500091,
+    500092,
+    500093,
+    500094,
+    500097,
+    500099,
+    500103,
+    500107,
+    500108,
+    500110,
+    500111,
+    500112,
+    500113,
+    500119,
+    500123,
+    500126,
+    500127,
+    500128,
+    500129,
+    500134,
+    500141,
+    500143,
+    500144,
+    500152,
+    500165,
+    500168,
+    500169,
+    500170,
+    500173,
+    500174,
+    500193,
+    500201,
+    500204,
+    500207,
+    500209,
+    500211,
+    500216,
+    500217,
+    500231,
+    500232,
+    500239,
+    500240,
+    500253,
+    500257,
+    500260,
+    500268,
+    500269,
+    500274,
+    500279,
+    500280,
+    500281,
+    500283,
+    500284,
+    500288,
+    500298,
+    500299,
+    500303,
+    500309,
+    500313,
+    500314,
+    500326,
+    500336,
+    500340,
+    500341,
+    500344,
+    500355,
+    500361,
+    500376,
+    500402,
+    500652,
+    500688,
+    500689,
+    500705,
+    500709,
+    500710,
+    500711,
+    500720,
+    500722,
+    500723,
+    500724,
+    500727,
+    500732,
+    500735,
+    500900,
+    500901,
+    500907,
+    500916,
+    500920,
+    500929,
+    500938,
+    500939,
+    500941,
+    500943,
+    500961,
+    500963,
+    500965,
+    500967,
+    500982,
+    500983,
+    500985,
+    501075,
+    501134,
+    501135,
+    501138,
+    501151,
+    501160,
+    501162,
+    501170,
+    501189,
+    501198,
+    501220,
+    501300,
+    501344,
+    501403,
+    501415,
+    501421,
+    501486,
+    501491,
+    501508,
+    501607,
+    501625,
+    501640,
+    501724,
+    501764,
+    501769,
+    501820,
+    501843,
+    501855,
+    501890,
+    501900,
+    501921,
+    501940,
+    501943,
+    502011,
+    502020,
+    502052,
+    502053,
+    502060,
+    502064,
+    502125,
+    502134,
+    502195,
+    502213,
+    502262,
+    502333,
+    502341,
+    502366,
+    502386,
+    502412,
+    502434,
+    502460,
+    502591,
+    502634,
+    502666,
+    502725,
+    502820,
+    502828,
+    502896,
+    502905,
+    502939,
+    502968,
+    502982,
+    503037,
+    503077,
+    503106,
+    503142,
+    503200,
+    503216,
+    503222,
+    503227,
+    503231,
+    503239,
+    503295,
+    503300,
+    503313,
+    503368,
+    503423,
+    503472,
+    503476,
+    503509,
+    503517,
+    503562,
+    503567,
+    503599,
+    503679,
+    503736,
+    503875,
+    503883,
+    503907,
+    503908,
+    503924,
+    504014,
+    504015,
+    504020,
+    504021,
+    504052,
+    504056,
+    504060,
+    504093,
+    504120,
+    504122,
+    504149,
+    504177,
+    504217,
+    504233,
+    504296,
+    504301,
+    504315,
+    504334,
+    504335,
+    504362,
+    504378,
+    504409,
+    504421,
+    504519,
+    504720,
+    520043,
+    520046,
+    520085,
+    520151,
+    520206,
+    520211,
+    520214,
+    520269,
+    520292,
+    520307,
+    520320,
+    520399,
+    520412,
+    520512,
+    520514,
+    520523,
+    524709,
+    524835,
+    524840,
+    524881,
+    524966,
+    524968,
+    524973,
+    524999,
+    526362,
+    534600,
+    534604,
+    535512,
+    535651,
+    536213,
+    555351,
+    560048,
+    560058,
+    560088,
+    560119,
+    560152,
+    560168,
+    560186,
+    560187,
+    560295,
+    560296,
+    560312,
+    560316,
+    560365,
+    560472,
+    560512,
+    560590,
+    560594,
+    560597,
+    560653,
+    560704,
+    560718,
+    560738,
+    560749,
+    560750,
+    560764,
+    560963,
+    560988,
+    562572,
+    570121,
+    570123,
+    570161,
+    570170,
+    572304,
+    572305,
+    573310,
+    583022,
+    620067,
+    630868,
+    630872,
+    681056,
+    681374,
+    704097,
+    704098,
+    704101,
+    704109,
+    704110,
+    704137,
+    704141,
+    704153,
+    704159,
+    704201,
+    704213,
+    704280,
+    704282,
+    704307,
+    704308,
+    704313,
+    704345,
+    704353,
+    704392,
+    704400,
+    704401,
+    704407,
+    704415,
+    704425,
+    704429,
+    704433,
+    704441,
+    704443,
+    704445,
+    704446,
+    704447,
+    704448,
+    704450,
+    704465,
+    704472,
+    704477,
+    704479,
+    704483,
+    704492,
+    704501,
+    704532,
+    704544,
+    704547,
+    704573,
+    704591,
+    704592,
+    704608,
+    704609,
+    704620,
+    704622,
+    704631,
+    704637,
+    704638,
+    704639,
+    704640,
+    704645,
+    704650,
+    704651,
+    704656,
+    704663,
+    704664,
+    704665,
+    704668,
+    704671,
+    704672,
+    704677,
+    704678,
+    704683,
+    704684,
+    704685,
+    704686,
+    704689,
+    704691,
+    704693,
+    704694,
+    704695,
+    704696,
+    704697,
+    704698,
+    704700,
+    704704,
+    704705,
+    704707,
+    704708,
+    704711,
+    704712,
+    704714,
+    704720,
+    704727,
+    704728,
+    704730,
+    704731,
+    704734,
+    704735,
+    704742,
+    704744,
+    704747,
+    704752,
+    704754,
+    704758,
+    704760,
+    704780,
+    704782,
+    704791,
+    704797,
+    704799,
+    704805,
+    704840,
+    704841,
+    704844,
+    704846,
+    704850,
+    704852,
+    704859,
+    704867,
+    704870,
+    704873,
+    704874,
+    704877,
+    704883,
+    704886,
+    704888,
+    704891,
+    704892,
+    704898,
+    704899,
+    704900,
+    704901,
+    704902,
+    704905,
+    704912,
+    704917,
+    704918,
+    704923,
+    704924,
+    704940,
+    704943,
+    704944,
+    704946,
+    704948,
+    704960,
+    704962,
+    704968,
+    704977,
+    704978,
+    704983,
+    704984,
+    704993,
+    704996,
+    705001,
+    705003,
+    705004,
+    705006,
+    705009,
+    705012,
+    705014,
+    705017,
+    705022,
+    705024,
+    705025,
+    705038,
+    705041,
+    705042,
+    705045,
+    705049,
+    705058,
+    705060,
+    705064,
+    705066,
+    705069,
+    705079,
+    705080,
+    705082,
+    705083,
+    705084,
+    705088,
+    705099,
+    705100,
+    705101,
+    705110,
+    705112,
+    705116,
+    705117,
+    705119,
+    705133,
+    705134,
+    705136,
+    705140,
+    705144,
+    705147,
+    705149,
+    705155,
+    705157,
+    705182,
+    705189,
+    705192,
+    705193,
+    705194,
+    705195,
+    705197,
+    705199,
+    705200,
+    705205,
+    705209,
+    705215,
+    705219,
+    705223,
+    705226,
+    705229,
+    705233,
+    705236,
+    705237,
+    705241,
+    705243,
+    705245,
+    705246,
+    705247,
+    705248,
+    705249,
+    705258,
+    705261,
+    705277,
+    705282,
+    705288,
+    705289,
+    705292,
+    705294,
+    705297,
+    705301,
+    705304,
+    705305,
+    705313,
+    705317,
+    705327,
+    705335,
+    705337,
+    705348,
+    705349,
+    705357,
+    705362,
+    705365,
+    705372,
+    705373,
+    705398,
+    705399,
+    705400,
+    705402,
+    705417,
+    705420,
+    705421,
+    705429,
+    705430,
+    705431,
+    705433,
+    705435,
+    705438,
+    705440,
+    705446,
+    705447,
+    705448,
+    705449,
+    705452,
+    705457,
+    705462,
+    705470,
+    705471,
+    705472,
+    705476,
+    705479,
+    705482,
+    705483,
+    705486,
+    705489,
+    705492,
+    705495,
+    705501,
+    705504,
+    705510,
+    705523,
+    705525,
+    705527,
+    705530,
+    705532,
+    705535,
+    705536,
+    705544,
+    705545,
+    705549,
+    705552,
+    705553,
+    705557,
+    705561,
+    705566,
+    705567,
+    705578,
+    705584,
+    705585,
+    705603,
+    705612,
+    705616,
+    705617,
+    705622,
+    705624,
+    705630,
+    705631,
+    705635,
+    705647,
+    705654,
+    705664,
+    705670,
+    705673,
+    705679,
+    705680,
+    705681,
+    705685,
+    705687,
+    705688,
+    705697,
+    705703,
+    705706,
+    705707,
+    705712,
+    705713,
+    705718,
+    705729,
+    705737,
+    705739,
+    705740,
+    705741,
+    705756,
+    705758,
+    705760,
+    705762,
+    705763,
+    705770,
+    705771,
+    705778,
+    705797,
+    705804,
+    705814,
+    705816,
+    705818,
+    705822,
+    705823,
+    705828,
+    705829,
+    705832,
+    705835,
+    705836,
+    705853,
+    705854,
+    705857,
+    705862,
+    705863,
+    705865,
+    705868,
+    705869,
+    705873,
+    705874,
+    705881,
+    705886,
+    705891,
+    705896,
+    705897,
+    705905,
+    705908,
+    705914,
+    705915,
+    705919,
+    705920,
+    705923,
+    705932,
+    705933,
+    705934,
+    705940,
+    705943,
+    705944,
+    705946,
+    705951,
+    705954,
+    705955,
+    705976,
+    705977,
+    705981,
+    705983,
+    705988,
+    705989,
+    705990,
+    705992,
+    705994,
+    706003,
+    706008,
+    706011,
+    706020,
+    706028,
+    706031,
+    706034,
+    706043,
+    706044,
+    706045,
+    706047,
+    706050,
+    706054,
+    706062,
+    706066,
+    706068,
+    706073,
+    706081,
+    706082,
+    706086,
+    706087,
+    706089,
+    706090,
+    706094,
+    706097,
+    706104,
+    706109,
+    706110,
+    706111,
+    706112,
+    706115,
+    706120,
+    706124,
+    706125,
+    706126,
+    706127,
+    706132,
+    706135,
+    706136,
+    706140,
+    706141,
+    706147,
+    706149,
+    706151,
+    706152,
+    706154,
+    706156,
+    706158,
+    706168,
+    706172,
+    706173,
+    706180,
+    706184,
+    706186,
+    706195,
+    706196,
+    706199,
+    706202,
+    706205,
+    706212,
+    706213,
+    706214,
+    706217,
+    706221,
+    706249,
+    706251,
+    706254,
+    706278,
+    706283,
+    706286,
+    706341,
+    706349,
+    706364,
+    706374,
+    706377,
+    706380,
+    706596,
+    706600,
+    706605,
+    706630,
+    706634,
+    706647,
+    706665,
+    706666,
+    706667,
+    706731,
+    706742,
+    706867,
+    706973,
+    707044,
+    707717,
+    800013,
+    800022,
+    800023,
+    800050,
+    800079,
+    800087,
+    800088,
+    800089,
+    800091,
+    800104,
+    800108,
+    800120,
+    800126,
+    800128,
+    800135,
+    800142,
+    800147,
+    800156,
+    800161,
+    800168,
+    800169,
+    800174,
+    800175,
+    800177,
+    800194,
+    800196,
+    800197,
+    800198,
+    800199,
+    800211,
+    800215,
+    800218,
+    800233,
+    800234,
+    800243,
+    800260,
+    800261,
+    800262,
+    800266,
+    800267,
+    800269,
+    800270,
+    800272,
+    800278,
+    800306,
+    800308,
+    800311,
+    800316,
+    800317,
+    800318,
+    800321,
+    800322,
+    800333,
+    800338,
+    800345,
+    800348,
+    800354,
+    800357,
+    800365,
+    800366,
+    800367,
+    800368,
+    800370,
+    800371,
+    800373,
+    800375,
+    800376,
+    800380,
+    800381,
+    800403,
+    800413,
+    800416,
+    800452,
+    800468,
+    800495,
+    800496,
+    800499,
+    800501,
+    800510,
+    800511,
+    800516,
+    800518,
+    800568,
+    800572,
+    800581,
+    800586,
+    800606,
+    800610,
+    800611,
+    800614,
+    800622,
+    800624,
+    800666,
+    800669,
+    800672,
+    800692,
+    800706,
+    800711,
+    800732,
+    800733,
+    800735,
+    800739,
+    800741,
+    800768,
+    800774,
+    800792,
+    800794,
+    800806,
+    800808,
+    800809,
+    800813,
+    800819,
+    800825,
+    800841,
+    800848,
+    800852,
+    800863,
+    800864,
+    800869,
+    800879,
+    800889,
+    800891,
+    800892,
+    800905,
+    800912,
+    800938,
+    800940,
+    800946,
+    800950,
+    800978,
+    800995,
+    801001,
+    801002,
+    801036,
+    801040,
+    801041,
+    801053,
+    801069,
+    801075,
+    801081,
+    801084,
+    801091,
+    801092,
+    801125,
+    801127,
+    801128,
+    801130,
+    801131,
+    801139,
+    801141,
+    801142,
+    801153,
+    801157,
+    801165,
+    801180,
+    801181,
+    801205,
+    801221,
+    801233,
+    801242,
+    801275,
+    801278,
+    801280,
+    801283,
+    801288,
+    801290,
+    801291,
+    801293,
+    801294,
+    801295,
+    801297,
+    801303,
+    801304,
+    801306,
+    801332,
+    801337,
+    801351,
+    801352,
+    801381,
+    801382,
+    801391,
+    801393,
+    801394,
+    801428,
+    801434,
+    801440,
+    801441,
+    801443,
+    801445,
+    801448,
+    801451,
+    801458,
+    801463,
+    801477,
+    801478,
+    801479,
+    801487,
+    801517,
+    801523,
+    801524,
+    801544,
+    801564,
+    801568,
+    801569,
+    801583,
+    801584,
+    801585,
+    801609,
+    801626,
+    801629,
+    801633,
+    801643,
+    801665,
+    801667,
+    801669,
+    801672,
+    801678,
+    801680,
+    801695,
+    801696,
+    801697,
+    801705,
+    801707,
+    801708,
+    801710,
+    801718,
+    801722,
+    801732,
+    801735,
+    801736,
+    801746,
+    801755,
+    801756,
+    801758,
+    801765,
+    801766,
+    801768,
+    801770,
+    801772,
+    801776,
+    801784,
+    801786,
+    801787,
+    801789,
+    801790,
+    801791,
+    801792,
+    801793,
+    801794,
+    801795,
+    801798,
+    801799,
+    801800,
+    801808,
+    801813,
+    801815,
+    801817,
+    801818,
+    801820,
+    801825,
+    801828,
+    801839,
+    801862,
+    801871,
+    801872,
+    801873,
+    801884,
+    801908,
+    801911,
+    801915,
+    801925,
+    801939,
+    801941,
+    801942,
+    801948,
+    801956,
+    801957,
+    801967,
+    801969,
+    801970,
+    801973,
+    801974,
+    801985,
+    801990,
+    801991,
+    801997,
+    801998,
+    802001,
+    802008,
+    802013,
+    802022,
+    802024,
+    802034,
+    802035,
+    802036,
+    802042,
+    802051,
+    802059,
+    802060,
+    802065,
+    802075,
+    802089,
+    802093,
+    802117,
+    802119,
+    802135,
+    802137,
+    802141,
+    802142,
+    802157,
+    802165,
+    802166,
+    802171,
+    802174,
+    802175,
+    802189,
+    802195,
+    802197,
+    802205,
+    802218,
+    802229,
+    802231,
+    802232,
+    802241,
+    802263,
+    802264,
+    802267,
+    802279,
+    802282,
+    802284,
+    802292,
+    802293,
+    802305,
+    802310,
+    802313,
+    802314,
+    802316,
+    802326,
+    802329,
+    802344,
+    802987,
+    803007,
+    803008,
+    803009,
+    803010,
+    803011,
+    803012,
+    803014,
+    803015,
+    803016,
+    803017,
+    803037,
+    803087,
+    803103,
+    803107,
+    803110,
+    803112,
+    803117,
+    803118,
+    803130,
+    803132,
+    803149,
+    803154,
+    803157,
+    803161,
+    803162,
+    803169,
+    803177,
+    803179,
+    803180,
+    803183,
+    803193,
+    803194,
+    803198,
+    803199,
+    803201,
+    803203,
+    803205,
+    803825,
+    803946,
+    803953,
+    803955,
+    803959,
+    803960,
+    803961,
+    803964,
+    803966,
+    803975,
+    803981,
+    803984,
+    803987,
+    803988,
+    803989,
+    803996,
+    804001,
+    804010,
+    804015,
+    804016,
+    804017,
+    804019,
+    804030,
+    804042,
+    804048,
+    804049,
+    804058,
+    804126,
+    804127,
+    804128,
+    804129,
+    804151,
+    804154,
+    804156,
+    804164,
+    804165,
+    804166,
+    804168,
+    804174,
+    804176,
+    804184,
+    804195,
+    804198,
+    804204,
+    804206,
+    804218,
+    804220,
+    804228,
+    804231,
+    804275,
+    804285,
+    804287,
+    804295,
+    804331,
+    804332,
+    804344,
+    804348,
+    804350,
+    804353,
+    804357,
+    804360,
+    804386,
+    804387,
+    804389,
+    804397,
+    804415,
+    804418,
+    804420,
+    804422,
+    804431,
+    804432,
+    804433,
+    804434,
+    804448,
+    804450,
+    804461,
+    804487,
+    804492,
+    804493,
+    804495,
+    804497,
+    804498,
+    804501,
+    804513,
+    804522,
+    804535,
+    804579,
+    804584,
+    804597,
+    804607,
+    804615,
+    804616,
+    804621,
+    804624,
+    804664,
+    804666,
+    804669,
+    804674,
+    804677,
+    804680,
+    804681,
+    804682,
+    804687,
+    804688,
+    804689,
+    804690,
+    804691,
+    804700,
+    804707,
+    804713,
+    804717,
+    804723,
+    804724,
+    804727,
+    804732,
+    804738,
+    804741,
+    804742,
+    804743,
+    804744,
+    804748,
+    804753,
+    804759,
+    804767,
+    804777,
+    804780,
+    804781,
+    804782,
+    804783,
+    804784,
+    804790,
+    804791,
+    804792,
+    804793,
+    804794,
+    804795,
+    804796,
+    804797,
+    804798,
+    804799,
+    804802,
+    804803,
+    804814,
+    804815,
+    804816,
+    804817,
+    804818,
+    804819,
+    804820,
+    804821,
+    804829,
+    804831,
+    804835,
+    804841,
+    804842,
+    804861,
+    804868,
+    804870,
+    804880,
+    804885,
+    804896,
+    804902,
+    804908,
+    804909,
+    804910,
+    804913,
+    804914,
+    804916,
+    804919,
+    804920,
+    804931,
+    804936,
+    804938,
+    804940,
+    804941,
+    804942,
+    804965,
+    804967,
+    804973,
+    804976,
+    804980,
+    804988,
+    804991,
+    805029,
+    805042,
+    805096,
+    805097,
+    805098,
+    805101,
+    805108,
+    805111,
+    805116,
+    805119,
+    805120,
+    805125,
+    805133,
+    805136,
+    805141,
+    805143,
+    805145,
+    805152,
+    805156,
+    805157,
+    805162,
+    805164,
+    805166,
+    805167,
+    805168,
+    805170,
+    805189,
+    805193,
+    805200,
+    805202,
+    805251,
+    805253,
+    805304,
+    805309,
+    805312,
+    805313,
+    805317,
+    805318,
+    805319,
+    805320,
+    805321,
+    805322,
+    805324,
+    805325,
+    805327,
+    805330,
+    805351,
+    805356,
+    805361,
+    805367,
+    805368,
+    805376,
+    805380,
+    805381,
+    805382,
+    805383,
+    805388,
+    805391,
+    805392,
+    805405,
+    805414,
+    805419,
+    805425,
+    805432,
+    805435,
+    805438,
+    805449,
+    805451,
+    805472,
+    805475,
+    805476,
+    805479,
+    805480,
+    805487,
+    805507,
+    805521,
+    805522,
+    805540,
+    805544,
+    805545,
+    805568,
+    805576,
+    805584,
+    805588,
+    805605,
+    805606,
+    805616,
+    805619,
+    805624,
+    805631,
+    805632,
+    805634,
+    805641,
+    805664,
+    805667,
+    805668,
+    805670,
+    805676,
+    805686,
+    805692,
+    805698,
+    805700,
+    805702,
+    805704,
+    805705,
+    805711,
+    805721,
+    805723,
+    805731,
+    805736,
+    805739,
+    805761,
+    805762,
+    805769,
+    805776,
+    805777,
+    805795,
+    805797,
+    805798,
+    805802,
+    805803,
+    805831,
+    805833,
+    805836,
+    805845,
+    805846,
+    805848,
+    805849,
+    805887,
+    805908,
+    805913,
+    805919,
+    805920,
+    805949,
+    805950,
+    806022,
+    806042,
+    806061,
+    806077,
+    806082,
+    806090,
+    806114,
+    806118,
+    806120,
+    806121,
+    806122,
+    806130,
+    806132,
+    806136,
+    806138,
+    806150,
+    806151,
+    806156,
+    806157,
+    806168,
+    806169,
+    806170,
+    806171,
+    806172,
+    806173,
+    806178,
+    806180,
+    806182,
+    806207,
+    806208,
+    806211,
+    806220,
+    806221,
+    806223,
+    806242,
+    806244,
+    806248,
+    806252,
+    806253,
+    806271,
+    806276,
+    806282,
+    806285,
+    806291,
+    806316,
+    806320,
+    806327,
+    806329,
+    806332,
+    806339,
+    806341,
+    806345,
+    806359,
+    806371,
+    806386,
+    806394,
+    806396,
+    806401,
+    806405,
+    806420,
+    806426,
+    806474,
+    806475,
+    806496,
+    806501,
+    806518,
+    806521,
+    806551,
+    806556,
+    806604,
+    808012,
+    983368,
+    1257670
+  ],
+  "non_matching_edge_hypotheses": [
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "12-33-4-4",
+      "source_spell_id": 705209,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        29799
+      ],
+      "target_node_id": "12-33-4-3",
+      "target_spell_id": 801782
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        31219
+      ],
+      "source_node_id": "12-33-4-5a",
+      "source_spell_id": 800132,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "12-33-4-4",
+      "target_spell_id": 705209
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        5055
+      ],
+      "source_node_id": "13-35-1-3",
+      "source_spell_id": 572871,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        7131,
+        12264
+      ],
+      "target_node_id": "13-35-2-2",
+      "target_spell_id": 503748
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6020
+      ],
+      "source_node_id": "13-35-1-7a",
+      "source_spell_id": 705859,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6022
+      ],
+      "target_node_id": "13-35-3-6",
+      "target_spell_id": 707212
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7131,
+        12264
+      ],
+      "source_node_id": "13-35-2-2",
+      "source_spell_id": 503748,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        6645
+      ],
+      "target_node_id": "13-35-4-1",
+      "target_spell_id": 561069
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6022
+      ],
+      "source_node_id": "13-35-3-6",
+      "source_spell_id": 707212,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        30823
+      ],
+      "target_node_id": "13-35-4-5",
+      "target_spell_id": 500950
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6014
+      ],
+      "source_node_id": "13-35-3-7",
+      "source_spell_id": 560544,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6022
+      ],
+      "target_node_id": "13-35-3-6",
+      "target_spell_id": 707212
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7128
+      ],
+      "source_node_id": "13-35-4-3",
+      "source_spell_id": 802710,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        7131,
+        12264
+      ],
+      "target_node_id": "13-35-2-2",
+      "target_spell_id": 503748
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30823
+      ],
+      "source_node_id": "13-35-4-5",
+      "source_spell_id": 500950,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        31137
+      ],
+      "target_node_id": "13-35-5-4",
+      "target_spell_id": 802219
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        31137
+      ],
+      "source_node_id": "13-35-5-4",
+      "source_spell_id": 802219,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7128
+      ],
+      "target_node_id": "13-35-4-3",
+      "target_spell_id": 802710
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6015
+      ],
+      "source_node_id": "13-35-6-5",
+      "source_spell_id": 705850,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        31137
+      ],
+      "target_node_id": "13-35-5-4",
+      "target_spell_id": 802219
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        11323
+      ],
+      "source_node_id": "13-87-4-7a",
+      "source_spell_id": 301297,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        7131,
+        12264
+      ],
+      "target_node_id": "13-87-5-6",
+      "target_spell_id": 503748
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7131,
+        12264
+      ],
+      "source_node_id": "13-87-5-6",
+      "source_spell_id": 503748,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        12525
+      ],
+      "target_node_id": "13-87-4-5a",
+      "target_spell_id": 807855
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7131,
+        12264
+      ],
+      "source_node_id": "13-87-5-6",
+      "source_spell_id": 503748,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        6525
+      ],
+      "target_node_id": "13-87-4-5b",
+      "target_spell_id": 806469
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7131,
+        12264
+      ],
+      "source_node_id": "13-87-5-6",
+      "source_spell_id": 503748,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        6042
+      ],
+      "target_node_id": "13-87-6-5",
+      "target_spell_id": 504465
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7875
+      ],
+      "source_node_id": "15-40-2-2",
+      "source_spell_id": 705467,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        9414
+      ],
+      "target_node_id": "15-40-4-1",
+      "target_spell_id": 802273
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        9414
+      ],
+      "source_node_id": "15-40-4-1",
+      "source_spell_id": 802273,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7414
+      ],
+      "target_node_id": "15-40-4-0",
+      "target_spell_id": 807918
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7583
+      ],
+      "source_node_id": "15-94-1-6",
+      "source_spell_id": 680496,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "15-94-2-5",
+      "target_spell_id": 804432
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "15-94-2-5",
+      "source_spell_id": 804432,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        31213
+      ],
+      "target_node_id": "15-94-1-4",
+      "target_spell_id": 681093
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        12431
+      ],
+      "source_node_id": "18-87-4-7",
+      "source_spell_id": 504151,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        34414,
+        34451
+      ],
+      "target_node_id": "18-87-6-6",
+      "target_spell_id": 300534
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        34414,
+        34451
+      ],
+      "source_node_id": "18-87-6-6",
+      "source_spell_id": 300534,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        29431
+      ],
+      "target_node_id": "18-87-4-5",
+      "target_spell_id": 802188
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        34414,
+        34451
+      ],
+      "source_node_id": "18-87-6-6",
+      "source_spell_id": 300534,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        29429
+      ],
+      "target_node_id": "18-87-6-5",
+      "target_spell_id": 806134
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        34414,
+        34451
+      ],
+      "source_node_id": "18-87-6-6",
+      "source_spell_id": 300534,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        29996
+      ],
+      "target_node_id": "18-87-8-5",
+      "target_spell_id": 801121
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        29970
+      ],
+      "source_node_id": "18-87-6-7",
+      "source_spell_id": 300543,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        34414,
+        34451
+      ],
+      "target_node_id": "18-87-6-6",
+      "target_spell_id": 300534
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        34404
+      ],
+      "source_node_id": "18-87-7-7",
+      "source_spell_id": 705315,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        34414,
+        34451
+      ],
+      "target_node_id": "18-87-6-6",
+      "target_spell_id": 300534
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7024
+      ],
+      "source_node_id": "19-51-0-6",
+      "source_spell_id": 705291,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6920
+      ],
+      "target_node_id": "19-51-0-5",
+      "target_spell_id": 705285
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34381
+      ],
+      "source_node_id": "19-51-1-7",
+      "source_spell_id": 706312,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7024
+      ],
+      "target_node_id": "19-51-0-6",
+      "target_spell_id": 705291
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30608
+      ],
+      "source_node_id": "19-51-6-6",
+      "source_spell_id": 527023,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34361
+      ],
+      "target_node_id": "19-51-7-4a",
+      "target_spell_id": 300504
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30608
+      ],
+      "source_node_id": "19-51-6-6",
+      "source_spell_id": 527023,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        12361
+      ],
+      "target_node_id": "19-51-7-4b",
+      "target_spell_id": 301339
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34361
+      ],
+      "source_node_id": "19-51-7-4a",
+      "source_spell_id": 300504,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34343
+      ],
+      "target_node_id": "19-51-6-3",
+      "target_spell_id": 680891
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34361
+      ],
+      "source_node_id": "19-51-7-4a",
+      "source_spell_id": 300504,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6861
+      ],
+      "target_node_id": "19-51-7-3",
+      "target_spell_id": 520009
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34371
+      ],
+      "source_node_id": "19-51-8-5",
+      "source_spell_id": 300524,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34361
+      ],
+      "target_node_id": "19-51-7-4a",
+      "target_spell_id": 300504
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34371
+      ],
+      "source_node_id": "19-51-8-5",
+      "source_spell_id": 300524,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        12361
+      ],
+      "target_node_id": "19-51-7-4b",
+      "target_spell_id": 301339
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7788
+      ],
+      "source_node_id": "21-54-3-3",
+      "source_spell_id": 704317,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34153
+      ],
+      "target_node_id": "21-54-1-2",
+      "target_spell_id": 707888
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7788
+      ],
+      "source_node_id": "21-54-3-3",
+      "source_spell_id": 704317,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7789
+      ],
+      "target_node_id": "21-54-4-2",
+      "target_spell_id": 705028
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7905
+      ],
+      "source_node_id": "21-54-3-6",
+      "source_spell_id": 707380,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29914
+      ],
+      "target_node_id": "21-54-4-5",
+      "target_spell_id": 560688
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7789
+      ],
+      "source_node_id": "21-54-4-2",
+      "source_spell_id": 705028,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34151
+      ],
+      "target_node_id": "21-54-2-1",
+      "target_spell_id": 705032
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7789
+      ],
+      "source_node_id": "21-54-4-2",
+      "source_spell_id": 705028,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29447
+      ],
+      "target_node_id": "21-54-6-1",
+      "target_spell_id": 300700
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7787
+      ],
+      "source_node_id": "21-54-4-4",
+      "source_spell_id": 802039,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7788
+      ],
+      "target_node_id": "21-54-3-3",
+      "target_spell_id": 704317
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29914
+      ],
+      "source_node_id": "21-54-4-5",
+      "source_spell_id": 560688,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7787
+      ],
+      "target_node_id": "21-54-4-4",
+      "target_spell_id": 802039
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6348
+      ],
+      "source_node_id": "21-54-4-7",
+      "source_spell_id": 706281,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29914
+      ],
+      "target_node_id": "21-54-4-5",
+      "target_spell_id": 560688
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        31283
+      ],
+      "source_node_id": "21-54-5-3",
+      "source_spell_id": 300706,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7789
+      ],
+      "target_node_id": "21-54-4-2",
+      "target_spell_id": 705028
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        31283
+      ],
+      "source_node_id": "21-54-5-3",
+      "source_spell_id": 300706,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34155
+      ],
+      "target_node_id": "21-54-7-2",
+      "target_spell_id": 301249
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6944
+      ],
+      "source_node_id": "21-54-5-6",
+      "source_spell_id": 560812,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29914
+      ],
+      "target_node_id": "21-54-4-5",
+      "target_spell_id": 560688
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29447
+      ],
+      "source_node_id": "21-54-6-1",
+      "source_spell_id": 300700,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        31178
+      ],
+      "target_node_id": "21-54-4-0",
+      "target_spell_id": 500075
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34136
+      ],
+      "source_node_id": "21-54-6-4",
+      "source_spell_id": 520227,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34155
+      ],
+      "target_node_id": "21-54-7-2",
+      "target_spell_id": 301249
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34155
+      ],
+      "source_node_id": "21-54-7-2",
+      "source_spell_id": 301249,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29447
+      ],
+      "target_node_id": "21-54-6-1",
+      "target_spell_id": 300700
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34152
+      ],
+      "source_node_id": "21-54-7-6",
+      "source_spell_id": 704312,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        31284
+      ],
+      "target_node_id": "21-54-8-5",
+      "target_spell_id": 807493
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34148
+      ],
+      "source_node_id": "21-54-8-4",
+      "source_spell_id": 500071,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34155
+      ],
+      "target_node_id": "21-54-7-2",
+      "target_spell_id": 301249
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        31284
+      ],
+      "source_node_id": "21-54-8-5",
+      "source_spell_id": 807493,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34148
+      ],
+      "target_node_id": "21-54-8-4",
+      "target_spell_id": 500071
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7826
+      ],
+      "source_node_id": "22-58-4-8",
+      "source_spell_id": 520045,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        30905
+      ],
+      "target_node_id": "22-58-5-7",
+      "target_spell_id": 560310
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6184
+      ],
+      "source_node_id": "22-58-5-6",
+      "source_spell_id": 570149,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7912
+      ],
+      "target_node_id": "22-58-4-5",
+      "target_spell_id": 801271
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6184
+      ],
+      "source_node_id": "22-58-5-6",
+      "source_spell_id": 570149,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29571
+      ],
+      "target_node_id": "22-58-6-5",
+      "target_spell_id": 804451
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30905
+      ],
+      "source_node_id": "22-58-5-7",
+      "source_spell_id": 560310,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6184
+      ],
+      "target_node_id": "22-58-5-6",
+      "target_spell_id": 570149
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6652
+      ],
+      "source_node_id": "22-58-6-7",
+      "source_spell_id": 706134,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29571
+      ],
+      "target_node_id": "22-58-6-5",
+      "target_spell_id": 804451
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6192
+      ],
+      "source_node_id": "22-58-6-8",
+      "source_spell_id": 706098,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6702
+      ],
+      "target_node_id": "22-58-8-7",
+      "target_spell_id": 804505
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6702
+      ],
+      "source_node_id": "22-58-8-7",
+      "source_spell_id": 804505,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29570
+      ],
+      "target_node_id": "22-58-8-6",
+      "target_spell_id": 806302
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29779
+      ],
+      "source_node_id": "23-60-10-4",
+      "source_spell_id": 301303,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        4436
+      ],
+      "target_node_id": "23-60-10-2",
+      "target_spell_id": 560045
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        4438
+      ],
+      "source_node_id": "23-60-10-6",
+      "source_spell_id": 500981,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29779
+      ],
+      "target_node_id": "23-60-10-4",
+      "target_spell_id": 301303
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29772
+      ],
+      "source_node_id": "23-60-10-8",
+      "source_spell_id": 704676,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        4438
+      ],
+      "target_node_id": "23-60-10-6",
+      "target_spell_id": 500981
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        19778
+      ],
+      "source_node_id": "23-60-4-6",
+      "source_spell_id": 707562,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        4437
+      ],
+      "target_node_id": "23-60-5-5",
+      "target_spell_id": 704669
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33723
+      ],
+      "source_node_id": "23-60-4-7",
+      "source_spell_id": 300958,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11438
+      ],
+      "target_node_id": "23-60-6-6",
+      "target_spell_id": 704681
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        4437
+      ],
+      "source_node_id": "23-60-5-5",
+      "source_spell_id": 704669,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29778
+      ],
+      "target_node_id": "23-60-4-4",
+      "target_spell_id": 805427
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        11438
+      ],
+      "source_node_id": "23-60-6-6",
+      "source_spell_id": 704681,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        4437
+      ],
+      "target_node_id": "23-60-5-5",
+      "target_spell_id": 704669
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        11438
+      ],
+      "source_node_id": "23-60-6-6",
+      "source_spell_id": 704681,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33731
+      ],
+      "target_node_id": "23-60-7-5",
+      "target_spell_id": 560620
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        8100
+      ],
+      "source_node_id": "23-60-7-7",
+      "source_spell_id": 707588,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11438
+      ],
+      "target_node_id": "23-60-6-6",
+      "target_spell_id": 704681
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7176
+      ],
+      "source_node_id": "24-62-6-7",
+      "source_spell_id": 704856,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7009
+      ],
+      "target_node_id": "24-62-7-6",
+      "target_spell_id": 560525
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7174
+      ],
+      "source_node_id": "24-62-6-8",
+      "source_spell_id": 520019,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11803
+      ],
+      "target_node_id": "24-62-8-7b",
+      "target_spell_id": 704815
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7009
+      ],
+      "source_node_id": "24-62-7-6",
+      "source_spell_id": 560525,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6500
+      ],
+      "target_node_id": "24-62-6-5",
+      "target_spell_id": 707482
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7009
+      ],
+      "source_node_id": "24-62-7-6",
+      "source_spell_id": 560525,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7171
+      ],
+      "target_node_id": "24-62-8-4",
+      "target_spell_id": 300757
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7171
+      ],
+      "source_node_id": "24-62-8-4",
+      "source_spell_id": 300757,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33877
+      ],
+      "target_node_id": "24-62-6-3",
+      "target_spell_id": 704823
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7803
+      ],
+      "source_node_id": "24-62-8-7a",
+      "source_spell_id": 680970,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7009
+      ],
+      "target_node_id": "24-62-7-6",
+      "target_spell_id": 560525
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        11964
+      ],
+      "source_node_id": "24-63-1-3",
+      "source_spell_id": 801905,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33863
+      ],
+      "target_node_id": "24-63-2-2",
+      "target_spell_id": 803452
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33864
+      ],
+      "source_node_id": "24-63-1-5",
+      "source_spell_id": 807319,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29964
+      ],
+      "target_node_id": "24-63-3-4",
+      "target_spell_id": 704812
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33863
+      ],
+      "source_node_id": "24-63-2-2",
+      "source_spell_id": 803452,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29935
+      ],
+      "target_node_id": "24-63-4-1",
+      "target_spell_id": 300956
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29964
+      ],
+      "source_node_id": "24-63-3-4",
+      "source_spell_id": 704812,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11145
+      ],
+      "target_node_id": "24-63-4-3a",
+      "target_spell_id": 707479
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29964
+      ],
+      "source_node_id": "24-63-3-4",
+      "source_spell_id": 704812,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7045
+      ],
+      "target_node_id": "24-63-4-3b",
+      "target_spell_id": 707325
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        11874
+      ],
+      "source_node_id": "24-63-3-6a",
+      "source_spell_id": 707503,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "24-63-4-5",
+      "target_spell_id": 802119
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "24-63-4-5",
+      "source_spell_id": 802119,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        29964
+      ],
+      "target_node_id": "24-63-3-4",
+      "target_spell_id": 704812
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "24-63-4-5",
+      "source_spell_id": 802119,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        29860
+      ],
+      "target_node_id": "24-63-5-4",
+      "target_spell_id": 503863
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        11936
+      ],
+      "source_node_id": "24-63-5-6a",
+      "source_spell_id": 707494,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "24-63-4-5",
+      "target_spell_id": 802119
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7938
+      ],
+      "source_node_id": "25-65-2-8",
+      "source_spell_id": 560977,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29477
+      ],
+      "target_node_id": "25-65-1-7",
+      "target_spell_id": 706909
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7938
+      ],
+      "source_node_id": "25-65-2-8",
+      "source_spell_id": 560977,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29478
+      ],
+      "target_node_id": "25-65-2-7",
+      "target_spell_id": 300307
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "25-65-2-9",
+      "source_spell_id": 704892,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        7938
+      ],
+      "target_node_id": "25-65-2-8",
+      "target_spell_id": 560977
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33959
+      ],
+      "source_node_id": "25-65-4-8",
+      "source_spell_id": 300308,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33957
+      ],
+      "target_node_id": "25-65-4-7",
+      "target_spell_id": 300298
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33959
+      ],
+      "source_node_id": "25-65-4-8",
+      "source_spell_id": 300308,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        31356
+      ],
+      "target_node_id": "25-65-6-7",
+      "target_spell_id": 300305
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        5176
+      ],
+      "source_node_id": "25-65-4-9",
+      "source_spell_id": 500712,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7938
+      ],
+      "target_node_id": "25-65-2-8",
+      "target_spell_id": 560977
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        6274
+      ],
+      "source_node_id": "25-66-1-6",
+      "source_spell_id": 500721,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33925
+      ],
+      "target_node_id": "25-66-0-5a",
+      "target_spell_id": 704434
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        6274
+      ],
+      "source_node_id": "25-66-1-6",
+      "source_spell_id": 500721,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33975
+      ],
+      "target_node_id": "25-66-0-5b",
+      "target_spell_id": 300290
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        6274
+      ],
+      "source_node_id": "25-66-1-6",
+      "source_spell_id": 500721,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        12975
+      ],
+      "target_node_id": "25-66-2-5",
+      "target_spell_id": 806382
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        30935
+      ],
+      "source_node_id": "25-66-1-7",
+      "source_spell_id": 807877,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6274
+      ],
+      "target_node_id": "25-66-1-6",
+      "target_spell_id": 500721
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        6310
+      ],
+      "source_node_id": "25-66-3-7",
+      "source_spell_id": 300284,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6274
+      ],
+      "target_node_id": "25-66-1-6",
+      "target_spell_id": 500721
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "25-87-1-7",
+      "source_spell_id": 706180,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        7899
+      ],
+      "target_node_id": "25-87-0-6",
+      "target_spell_id": 582589
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "25-87-1-7",
+      "source_spell_id": 706180,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        31123
+      ],
+      "target_node_id": "25-87-2-6",
+      "target_spell_id": 704880
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        31123
+      ],
+      "source_node_id": "25-87-2-6",
+      "source_spell_id": 704880,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33969
+      ],
+      "target_node_id": "25-87-2-5",
+      "target_spell_id": 803283
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        30205
+      ],
+      "source_node_id": "25-87-2-8",
+      "source_spell_id": 525060,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "25-87-1-7",
+      "target_spell_id": 706180
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30205
+      ],
+      "source_node_id": "25-87-2-8",
+      "source_spell_id": 525060,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6281
+      ],
+      "target_node_id": "25-87-3-7",
+      "target_spell_id": 300265
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6281
+      ],
+      "source_node_id": "25-87-3-7",
+      "source_spell_id": 300265,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        31123
+      ],
+      "target_node_id": "25-87-2-6",
+      "target_spell_id": 704880
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6281
+      ],
+      "source_node_id": "25-87-3-7",
+      "source_spell_id": 300265,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33952
+      ],
+      "target_node_id": "25-87-4-6",
+      "target_spell_id": 524879
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33951
+      ],
+      "source_node_id": "25-87-4-8",
+      "source_spell_id": 805110,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6281
+      ],
+      "target_node_id": "25-87-3-7",
+      "target_spell_id": 300265
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33965
+      ],
+      "source_node_id": "25-87-6-8",
+      "source_spell_id": 525065,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33968
+      ],
+      "target_node_id": "25-87-5-7a",
+      "target_spell_id": 302015
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33965
+      ],
+      "source_node_id": "25-87-6-8",
+      "source_spell_id": 525065,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7465
+      ],
+      "target_node_id": "25-87-5-7b",
+      "target_spell_id": 706188
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33965
+      ],
+      "source_node_id": "25-87-6-8",
+      "source_spell_id": 525065,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29479
+      ],
+      "target_node_id": "25-87-7-7a",
+      "target_spell_id": 301241
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33965
+      ],
+      "source_node_id": "25-87-6-8",
+      "source_spell_id": 525065,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6279
+      ],
+      "target_node_id": "25-87-7-7b",
+      "target_spell_id": 804633
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7940
+      ],
+      "source_node_id": "25-87-6-9",
+      "source_spell_id": 704881,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33951
+      ],
+      "target_node_id": "25-87-4-8",
+      "target_spell_id": 805110
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7940
+      ],
+      "source_node_id": "25-87-6-9",
+      "source_spell_id": 704881,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33965
+      ],
+      "target_node_id": "25-87-6-8",
+      "target_spell_id": 525065
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7614
+      ],
+      "source_node_id": "25-88-0-4",
+      "source_spell_id": 802043,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7617
+      ],
+      "target_node_id": "25-88-1-3",
+      "target_spell_id": 680558
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7618
+      ],
+      "source_node_id": "25-88-0-6",
+      "source_spell_id": 680555,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7614
+      ],
+      "target_node_id": "25-88-0-4",
+      "target_spell_id": 802043
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7617
+      ],
+      "source_node_id": "25-88-1-3",
+      "source_spell_id": 680558,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7612
+      ],
+      "target_node_id": "25-88-2-1",
+      "target_spell_id": 300268
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        12219
+      ],
+      "source_node_id": "25-88-1-5",
+      "source_spell_id": 806175,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7614
+      ],
+      "target_node_id": "25-88-0-4",
+      "target_spell_id": 802043
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        12219
+      ],
+      "source_node_id": "25-88-1-5",
+      "source_spell_id": 806175,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        9301
+      ],
+      "target_node_id": "25-88-2-4",
+      "target_spell_id": 706182
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29916
+      ],
+      "source_node_id": "25-88-1-7",
+      "source_spell_id": 680574,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7618
+      ],
+      "target_node_id": "25-88-0-6",
+      "target_spell_id": 680555
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29916
+      ],
+      "source_node_id": "25-88-1-7",
+      "source_spell_id": 680574,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        9302
+      ],
+      "target_node_id": "25-88-2-6",
+      "target_spell_id": 800463
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7622
+      ],
+      "source_node_id": "25-88-1-8",
+      "source_spell_id": 680579,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29916
+      ],
+      "target_node_id": "25-88-1-7",
+      "target_spell_id": 680574
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6275
+      ],
+      "source_node_id": "25-88-10-4",
+      "source_spell_id": 582307,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        9299
+      ],
+      "target_node_id": "25-88-10-2",
+      "target_spell_id": 804286
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33890
+      ],
+      "source_node_id": "25-88-10-6",
+      "source_spell_id": 680557,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6275
+      ],
+      "target_node_id": "25-88-10-4",
+      "target_spell_id": 582307
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        9301
+      ],
+      "source_node_id": "25-88-2-4",
+      "source_spell_id": 706182,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7617
+      ],
+      "target_node_id": "25-88-1-3",
+      "target_spell_id": 680558
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        9301
+      ],
+      "source_node_id": "25-88-2-4",
+      "source_spell_id": 706182,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        9759
+      ],
+      "target_node_id": "25-88-4-3a",
+      "target_spell_id": 803236
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        9301
+      ],
+      "source_node_id": "25-88-2-4",
+      "source_spell_id": 706182,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33888
+      ],
+      "target_node_id": "25-88-4-3b",
+      "target_spell_id": 680607
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7615
+      ],
+      "source_node_id": "25-88-3-5",
+      "source_spell_id": 560502,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        9301
+      ],
+      "target_node_id": "25-88-2-4",
+      "target_spell_id": 706182
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33893
+      ],
+      "source_node_id": "25-88-4-1",
+      "source_spell_id": 680569,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7404
+      ],
+      "target_node_id": "25-88-4-0",
+      "target_spell_id": 524876
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7620
+      ],
+      "source_node_id": "25-88-4-2",
+      "source_spell_id": 300278,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33893
+      ],
+      "target_node_id": "25-88-4-1",
+      "target_spell_id": 680569
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29654
+      ],
+      "source_node_id": "25-88-4-8",
+      "source_spell_id": 704889,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6545
+      ],
+      "target_node_id": "25-88-3-7",
+      "target_spell_id": 680609
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7627
+      ],
+      "source_node_id": "25-88-4-9",
+      "source_spell_id": 680575,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29654
+      ],
+      "target_node_id": "25-88-4-8",
+      "target_spell_id": 704889
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7624
+      ],
+      "source_node_id": "25-88-7-7",
+      "source_spell_id": 681425,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7619
+      ],
+      "target_node_id": "25-88-6-6",
+      "target_spell_id": 582308
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7624
+      ],
+      "source_node_id": "25-88-7-7",
+      "source_spell_id": 681425,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33896
+      ],
+      "target_node_id": "25-88-8-6",
+      "target_spell_id": 301182
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7625
+      ],
+      "source_node_id": "25-88-7-8",
+      "source_spell_id": 680570,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7616
+      ],
+      "target_node_id": "25-88-5-7",
+      "target_spell_id": 680581
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7625
+      ],
+      "source_node_id": "25-88-7-8",
+      "source_spell_id": 680570,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7624
+      ],
+      "target_node_id": "25-88-7-7",
+      "target_spell_id": 681425
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7626
+      ],
+      "source_node_id": "25-88-7-9",
+      "source_spell_id": 681088,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7625
+      ],
+      "target_node_id": "25-88-7-8",
+      "target_spell_id": 680570
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29651
+      ],
+      "source_node_id": "26-67-0-3",
+      "source_spell_id": 503637,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7701
+      ],
+      "target_node_id": "26-67-2-2",
+      "target_spell_id": 704793
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33851
+      ],
+      "source_node_id": "26-67-0-5",
+      "source_spell_id": 503639,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29651
+      ],
+      "target_node_id": "26-67-0-3",
+      "target_spell_id": 503637
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        13248
+      ],
+      "source_node_id": "26-67-10-6",
+      "source_spell_id": 574351,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        9247
+      ],
+      "target_node_id": "26-67-10-4",
+      "target_spell_id": 680748
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        9248
+      ],
+      "source_node_id": "26-67-10-8",
+      "source_spell_id": 807659,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        13248
+      ],
+      "target_node_id": "26-67-10-6",
+      "target_spell_id": 574351
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7701
+      ],
+      "source_node_id": "26-67-2-2",
+      "source_spell_id": 704793,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29656
+      ],
+      "target_node_id": "26-67-3-1",
+      "target_spell_id": 804381
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        33856
+      ],
+      "source_node_id": "26-67-2-4",
+      "source_spell_id": 704788,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7701
+      ],
+      "target_node_id": "26-67-2-2",
+      "target_spell_id": 704793
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        33802
+      ],
+      "source_node_id": "26-69-1-7",
+      "source_spell_id": 704771,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "26-69-1-6",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7739
+      ],
+      "source_node_id": "26-69-3-4",
+      "source_spell_id": 680801,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "26-69-3-3",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        5203
+      ],
+      "source_node_id": "26-69-3-5",
+      "source_spell_id": 706572,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "26-69-2-4",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        5203
+      ],
+      "source_node_id": "26-69-3-5",
+      "source_spell_id": 706572,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6690
+      ],
+      "target_node_id": "26-69-4-4",
+      "target_spell_id": 300876
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        6690
+      ],
+      "source_node_id": "26-69-4-4",
+      "source_spell_id": 300876,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "26-69-3-3",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        6690
+      ],
+      "source_node_id": "26-69-4-4",
+      "source_spell_id": 300876,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "26-69-5-3",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7746
+      ],
+      "source_node_id": "26-69-6-7",
+      "source_spell_id": 561062,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "26-69-5-6",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        11360
+      ],
+      "source_node_id": "26-89-10-6",
+      "source_spell_id": 805828,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        30660
+      ],
+      "target_node_id": "26-89-10-4",
+      "target_spell_id": 805524
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        11660
+      ],
+      "source_node_id": "26-89-10-8",
+      "source_spell_id": 801145,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11360
+      ],
+      "target_node_id": "26-89-10-6",
+      "target_spell_id": 805828
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7718
+      ],
+      "source_node_id": "27-71-1-2",
+      "source_spell_id": 300344,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29506
+      ],
+      "target_node_id": "27-71-2-1",
+      "target_spell_id": 681064
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34039
+      ],
+      "source_node_id": "27-71-2-5",
+      "source_spell_id": 300351,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        12832
+      ],
+      "target_node_id": "27-71-4-4",
+      "target_spell_id": 804253
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34041
+      ],
+      "source_node_id": "27-71-2-8",
+      "source_spell_id": 806123,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        30818
+      ],
+      "target_node_id": "27-71-1-7",
+      "target_spell_id": 807874
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34041
+      ],
+      "source_node_id": "27-71-2-8",
+      "source_spell_id": 806123,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        12351
+      ],
+      "target_node_id": "27-71-2-7",
+      "target_spell_id": 807963
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        12832
+      ],
+      "source_node_id": "27-71-4-4",
+      "source_spell_id": 804253,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        33998
+      ],
+      "target_node_id": "27-71-2-3",
+      "target_spell_id": 500147
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        12832
+      ],
+      "source_node_id": "27-71-4-4",
+      "source_spell_id": 804253,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        29183
+      ],
+      "target_node_id": "27-71-6-3",
+      "target_spell_id": 706735
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "27-71-4-5a",
+      "source_spell_id": 800233,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        12832
+      ],
+      "target_node_id": "27-71-4-4",
+      "target_spell_id": 804253
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7714
+      ],
+      "source_node_id": "27-71-4-6",
+      "source_spell_id": 804254,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34039
+      ],
+      "target_node_id": "27-71-2-5",
+      "target_spell_id": 300351
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7714
+      ],
+      "source_node_id": "27-71-4-6",
+      "source_spell_id": 804254,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "27-71-4-5a",
+      "target_spell_id": 800233
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7714
+      ],
+      "source_node_id": "27-71-4-6",
+      "source_spell_id": 804254,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34038
+      ],
+      "target_node_id": "27-71-4-5b",
+      "target_spell_id": 582832
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7714
+      ],
+      "source_node_id": "27-71-4-6",
+      "source_spell_id": 804254,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6653
+      ],
+      "target_node_id": "27-71-6-5",
+      "target_spell_id": 300355
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "27-71-4-7a",
+      "source_spell_id": 300350,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        29413
+      ],
+      "target_node_id": "27-71-2-6",
+      "target_spell_id": 534267
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "27-71-4-7a",
+      "source_spell_id": 300350,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        7714
+      ],
+      "target_node_id": "27-71-4-6",
+      "target_spell_id": 804254
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "27-71-4-7a",
+      "source_spell_id": 300350,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        72356
+      ],
+      "target_node_id": "27-71-6-6",
+      "target_spell_id": 504848
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        34043
+      ],
+      "source_node_id": "27-71-4-8",
+      "source_spell_id": 300357,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "27-71-4-7a",
+      "target_spell_id": 300350
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        34043
+      ],
+      "source_node_id": "27-71-4-8",
+      "source_spell_id": 300357,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "27-71-4-7b",
+      "target_spell_id": 301301
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30211
+      ],
+      "source_node_id": "27-71-4-9",
+      "source_spell_id": 804250,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34041
+      ],
+      "target_node_id": "27-71-2-8",
+      "target_spell_id": 806123
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30211
+      ],
+      "source_node_id": "27-71-4-9",
+      "source_spell_id": 804250,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34042
+      ],
+      "target_node_id": "27-71-6-8",
+      "target_spell_id": 704920
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6653
+      ],
+      "source_node_id": "27-71-6-5",
+      "source_spell_id": 300355,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        12832
+      ],
+      "target_node_id": "27-71-4-4",
+      "target_spell_id": 804253
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        72356
+      ],
+      "source_node_id": "27-71-6-6",
+      "source_spell_id": 504848,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6653
+      ],
+      "target_node_id": "27-71-6-5",
+      "target_spell_id": 300355
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "27-71-6-7a",
+      "source_spell_id": 704917,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        72356
+      ],
+      "target_node_id": "27-71-6-6",
+      "target_spell_id": 504848
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        34042
+      ],
+      "source_node_id": "27-71-6-8",
+      "source_spell_id": 704920,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "27-71-6-7a",
+      "target_spell_id": 704917
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34042
+      ],
+      "source_node_id": "27-71-6-8",
+      "source_spell_id": 704920,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11051
+      ],
+      "target_node_id": "27-71-6-7b",
+      "target_spell_id": 707433
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        34042
+      ],
+      "source_node_id": "27-71-6-8",
+      "source_spell_id": 704920,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6335
+      ],
+      "target_node_id": "27-71-7-7",
+      "target_spell_id": 572885
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        30817
+      ],
+      "source_node_id": "27-71-7-2",
+      "source_spell_id": 707077,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        30210
+      ],
+      "target_node_id": "27-71-6-1",
+      "target_spell_id": 704582
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6335
+      ],
+      "source_node_id": "27-71-7-7",
+      "source_spell_id": 572885,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        72356
+      ],
+      "target_node_id": "27-71-6-6",
+      "target_spell_id": 504848
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        6335
+      ],
+      "source_node_id": "27-71-7-7",
+      "source_spell_id": 572885,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7719
+      ],
+      "target_node_id": "27-71-8-6",
+      "target_spell_id": 804257
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7719
+      ],
+      "source_node_id": "27-71-8-6",
+      "source_spell_id": 804257,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        30212
+      ],
+      "target_node_id": "27-71-7-4",
+      "target_spell_id": 300349
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "27-90-4-5",
+      "source_spell_id": 704905,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        30684
+      ],
+      "target_node_id": "27-90-4-4",
+      "target_spell_id": 800612
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        31381
+      ],
+      "source_node_id": "27-90-4-6",
+      "source_spell_id": 520024,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "27-90-4-5",
+      "target_spell_id": 704905
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7370
+      ],
+      "source_node_id": "27-90-4-8",
+      "source_spell_id": 681252,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        12639
+      ],
+      "target_node_id": "27-90-4-7a",
+      "target_spell_id": 681448
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        7370
+      ],
+      "source_node_id": "27-90-4-8",
+      "source_spell_id": 681252,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7639
+      ],
+      "target_node_id": "27-90-4-7b",
+      "target_spell_id": 680620
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        29509
+      ],
+      "source_node_id": "27-90-4-9",
+      "source_spell_id": 805647,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        7370
+      ],
+      "target_node_id": "27-90-4-8",
+      "target_spell_id": 681252
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "29-76-1-9",
+      "source_spell_id": 681056,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        7728
+      ],
+      "target_node_id": "29-76-1-8",
+      "target_spell_id": 706455
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "29-76-1-9",
+      "source_spell_id": 681056,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        6142
+      ],
+      "target_node_id": "29-76-3-8",
+      "target_spell_id": 706956
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "29-92-0-6",
+      "source_spell_id": 300684,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        6132
+      ],
+      "target_node_id": "29-92-1-5",
+      "target_spell_id": 681048
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7121
+      ],
+      "source_node_id": "29-92-1-7",
+      "source_spell_id": 706938,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "29-92-0-6",
+      "target_spell_id": 300684
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        12223
+      ],
+      "source_node_id": "29-92-4-7",
+      "source_spell_id": 805884,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11788
+      ],
+      "target_node_id": "29-92-6-6",
+      "target_spell_id": 520153
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        11788
+      ],
+      "source_node_id": "29-92-6-6",
+      "source_spell_id": 520153,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        5291
+      ],
+      "target_node_id": "29-92-5-5",
+      "target_spell_id": 680768
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        11788
+      ],
+      "source_node_id": "29-92-6-6",
+      "source_spell_id": 520153,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6607
+      ],
+      "target_node_id": "29-92-7-5",
+      "target_spell_id": 706009
+    },
+    {
+      "same_ca_class_tab": true,
+      "source_ca_ids": [
+        5302
+      ],
+      "source_node_id": "29-92-7-7a",
+      "source_spell_id": 681320,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        11788
+      ],
+      "target_node_id": "29-92-6-6",
+      "target_spell_id": 520153
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "31-82-10-6",
+      "source_spell_id": 573310,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        9208
+      ],
+      "target_node_id": "31-82-10-4",
+      "target_spell_id": 574323
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        9909
+      ],
+      "source_node_id": "31-82-10-8",
+      "source_spell_id": 706340,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [],
+      "target_node_id": "31-82-10-6",
+      "target_spell_id": 573310
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        29363
+      ],
+      "source_node_id": "31-84-6-1",
+      "source_spell_id": 800144,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "31-84-5-10",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [
+        7334
+      ],
+      "source_node_id": "31-84-7-4a",
+      "source_spell_id": 574313,
+      "status": "dangling_community_node",
+      "target_ca_ids": [],
+      "target_node_id": "31-84-6-2",
+      "target_spell_id": null
+    },
+    {
+      "same_ca_class_tab": null,
+      "source_ca_ids": [],
+      "source_node_id": "32-85-10-8",
+      "source_spell_id": 707717,
+      "status": "unmapped_or_ambiguous",
+      "target_ca_ids": [
+        4802
+      ],
+      "target_node_id": "32-85-10-6",
+      "target_spell_id": 707876
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        34607
+      ],
+      "source_node_id": "32-86-0-6",
+      "source_spell_id": 706674,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        30032
+      ],
+      "target_node_id": "32-86-1-5",
+      "target_spell_id": 500270
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        34621
+      ],
+      "source_node_id": "32-86-1-7",
+      "source_spell_id": 705600,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        34607
+      ],
+      "target_node_id": "32-86-0-6",
+      "target_spell_id": 706674
+    },
+    {
+      "same_ca_class_tab": false,
+      "source_ca_ids": [
+        34617
+      ],
+      "source_node_id": "32-87-6-8",
+      "source_spell_id": 705583,
+      "status": "candidate_not_runtime_edge",
+      "target_ca_ids": [
+        6486
+      ],
+      "target_node_id": "32-87-7-7b",
+      "target_spell_id": 802669
+    }
+  ],
+  "runtime_dangling_source_ids": [],
+  "runtime_dangling_target_ids": [
+    6451,
+    7181,
+    17567
+  ],
+  "schema_version": 1,
+  "sources": [
+    {
+      "bytes": 80857,
+      "path": "edges.json",
+      "role": "ca",
+      "sha256": "394f4e18905a218bc1a48a85548c298889c51fd8876fe5887a5e9dbeb0bc9b53"
+    },
+    {
+      "bytes": 16629945,
+      "path": "entries.json",
+      "role": "ca",
+      "sha256": "787d4b3e32d7524f4d65c930dc7083aa050d810cba73bf02111c8345734c35fc"
+    },
+    {
+      "bytes": 7703,
+      "path": "classes.json",
+      "role": "hub",
+      "sha256": "ddb70df0c970409ff4b9fa2912fdfd114e8aaa5ed49e41cac0f2470788c70777"
+    },
+    {
+      "bytes": 113781,
+      "path": "skills/barbarian.json",
+      "role": "hub",
+      "sha256": "511ea8c180dcbdaedb5122a18fcd1967d1295d7ed2e8a7f13b826f11b783e626"
+    },
+    {
+      "bytes": 143684,
+      "path": "skills/bloodmage.json",
+      "role": "hub",
+      "sha256": "16f2a34f5d460e887a22aa66bf4bf2ffdcedb28a7f6a8aa95bbbae6d7eb32c81"
+    },
+    {
+      "bytes": 140104,
+      "path": "skills/chronomancer.json",
+      "role": "hub",
+      "sha256": "331654c7b5a733d0e26dd2d58bb3322af4097db8b4bd38ea878fd7c91893bb6a"
+    },
+    {
+      "bytes": 124408,
+      "path": "skills/cultist.json",
+      "role": "hub",
+      "sha256": "3d4d504771513dc412154fd3982543d8df769dbacf69beea6298d8222edee9d7"
+    },
+    {
+      "bytes": 84453,
+      "path": "skills/felsworn.json",
+      "role": "hub",
+      "sha256": "985a941130f042a6f1d9f23df08116c7b44bf003782eacaf716e6a1ec8fafde2"
+    },
+    {
+      "bytes": 127461,
+      "path": "skills/guardian.json",
+      "role": "hub",
+      "sha256": "70e5d983d9151a92b29f9aba13bd2e47ed18f7862e9eacceaa54a263055724c5"
+    },
+    {
+      "bytes": 103058,
+      "path": "skills/knight-of-xoroth.json",
+      "role": "hub",
+      "sha256": "7060c738bb6f22661cc1865eec50ec8c20ef5694f36407fc8f456bafdb5cf65b"
+    },
+    {
+      "bytes": 126889,
+      "path": "skills/necromancer.json",
+      "role": "hub",
+      "sha256": "8347a7e1076178a5951df68df88071c3e036aa5b522a5789efe5314b0827f41f"
+    },
+    {
+      "bytes": 119951,
+      "path": "skills/primalist.json",
+      "role": "hub",
+      "sha256": "5655a7de336056dfab1f5ad50b9be964600379a889d7d0090ae25423e3cd4b67"
+    },
+    {
+      "bytes": 109515,
+      "path": "skills/pyromancer.json",
+      "role": "hub",
+      "sha256": "48642b80074fe31a9fc8bab8c7423b47300552ddbd59a6d8d558bbd9a92ec1ce"
+    },
+    {
+      "bytes": 130092,
+      "path": "skills/ranger.json",
+      "role": "hub",
+      "sha256": "8a0021d7908f94bf83e962fbd8adce3093572b808433782155ec6946fa6f2cf7"
+    },
+    {
+      "bytes": 94916,
+      "path": "skills/reaper.json",
+      "role": "hub",
+      "sha256": "b0241e77b3f8396705c4f20c90971d78567373a0d530fcce794acf2de789645f"
+    },
+    {
+      "bytes": 136148,
+      "path": "skills/runemaster.json",
+      "role": "hub",
+      "sha256": "15c41be811a776a425921e6d5c7852143effeddec5677f23c537ade4be8f1821"
+    },
+    {
+      "bytes": 129192,
+      "path": "skills/starcaller.json",
+      "role": "hub",
+      "sha256": "02a8a0aa78f7640b90e29936ac8a476bc9f9c5048db8dc3d2644856cd4eb41cb"
+    },
+    {
+      "bytes": 113673,
+      "path": "skills/stormbringer.json",
+      "role": "hub",
+      "sha256": "799d9c4d55790e42ccd9b880cfa995f38cecd3d3a0c5be632695343cbf7c9197"
+    },
+    {
+      "bytes": 113332,
+      "path": "skills/sun-cleric.json",
+      "role": "hub",
+      "sha256": "34e546e7f1f294384b55b4e65d2214bffec3ee9f4daf041ad4278d16eddde92f"
+    },
+    {
+      "bytes": 127272,
+      "path": "skills/templar.json",
+      "role": "hub",
+      "sha256": "bdc82d0c7cbfd3d58c0c5e5d90dfb68584daf7b1a4f000779bcc6ebb9abd37b9"
+    },
+    {
+      "bytes": 145472,
+      "path": "skills/tinker.json",
+      "role": "hub",
+      "sha256": "7960ec70331775c2e369f34a6d175f8489cb42a7695442410648c000277ad948"
+    },
+    {
+      "bytes": 143604,
+      "path": "skills/venomancer.json",
+      "role": "hub",
+      "sha256": "783311c35e65b608d76f2efd0509d676b58870e77700dd0becce28fa66c20002"
+    },
+    {
+      "bytes": 124825,
+      "path": "skills/witch-doctor.json",
+      "role": "hub",
+      "sha256": "c47bd8904b94706fb8f0c55974c926edbf99ed73052e64b499808dc7c2f5f4fa"
+    },
+    {
+      "bytes": 99850,
+      "path": "skills/witch-hunter.json",
+      "role": "hub",
+      "sha256": "f85fe11bc77e8a36b0981cc40860b9874e652d512f43557f40ddcb3e5dd7409f"
+    },
+    {
+      "bytes": 3432387,
+      "path": "spells/master_index.json",
+      "role": "hub",
+      "sha256": "5031936d1a7caa93664ba4e429467db61387b26a7c676041c4ba16a61e836cae"
+    },
+    {
+      "bytes": 82705,
+      "path": "talents/barbarian.json",
+      "role": "hub",
+      "sha256": "8419cc2ec8202fd54a99bba4e7b0274cc4739f35f62fa16c039df6b5cad01d36"
+    },
+    {
+      "bytes": 110943,
+      "path": "talents/bloodmage.json",
+      "role": "hub",
+      "sha256": "198ee58a6b86e0955ff6edc2fa55d07a13d6b55b570035975a174722aadb38c7"
+    },
+    {
+      "bytes": 82407,
+      "path": "talents/chronomancer.json",
+      "role": "hub",
+      "sha256": "ef22a38b512c8eaadd4a64323543ef5c7b8cfa75de7d1584c460bb5897c5a587"
+    },
+    {
+      "bytes": 102309,
+      "path": "talents/cultist.json",
+      "role": "hub",
+      "sha256": "e0160dd6bb95f94e5ebf8fe59a6f6fddfe94fae161a9f6606c52ccfdda0633f1"
+    },
+    {
+      "bytes": 81371,
+      "path": "talents/felsworn.json",
+      "role": "hub",
+      "sha256": "7cefc7649f064a35bc2d2fbaa810734b7b85790253e7867ed5650b3431715697"
+    },
+    {
+      "bytes": 81370,
+      "path": "talents/guardian.json",
+      "role": "hub",
+      "sha256": "dea5e10032c221918ad61575c2c719b06c3616cc0a5aaa79ed9c521639125e7c"
+    },
+    {
+      "bytes": 81310,
+      "path": "talents/knight-of-xoroth.json",
+      "role": "hub",
+      "sha256": "9b824c9d0931ba89aceb5800da06840259aa27ad2309b811c86812ebaa6efc3b"
+    },
+    {
+      "bytes": 82705,
+      "path": "talents/necromancer.json",
+      "role": "hub",
+      "sha256": "e5a0ed486f81dd3cc9a060b2e05c2ec3a5b417115ab8a4c838df61f2a934c180"
+    },
+    {
+      "bytes": 107705,
+      "path": "talents/primalist.json",
+      "role": "hub",
+      "sha256": "86ac543fb03512be57d65ccf891bbbfe66c45fdb5c18ed0bf2a2d7b46dda852a"
+    },
+    {
+      "bytes": 83056,
+      "path": "talents/pyromancer.json",
+      "role": "hub",
+      "sha256": "c50fff3773af3570850e622dbbae3df6a1659b5b60589f9071e2843691a34161"
+    },
+    {
+      "bytes": 84666,
+      "path": "talents/ranger.json",
+      "role": "hub",
+      "sha256": "1fd9b12c6afce3c08bdbe20fb97521fe687fe6a214ad56ca82741c7f780d8dbf"
+    },
+    {
+      "bytes": 79091,
+      "path": "talents/reaper.json",
+      "role": "hub",
+      "sha256": "65321a684cd22b50b7565a75c6e60022e8cab96ce84bd2cf38b6914485a1568c"
+    },
+    {
+      "bytes": 84008,
+      "path": "talents/runemaster.json",
+      "role": "hub",
+      "sha256": "be517a0194a4c7ec2d88d1750d30dc6d32ce6d1975ed69d07d2798dc12885e2d"
+    },
+    {
+      "bytes": 96070,
+      "path": "talents/starcaller.json",
+      "role": "hub",
+      "sha256": "4a9268118194bba80fa7f1ed3f133045d51a306d831406f85e98cbc719ad8300"
+    },
+    {
+      "bytes": 82086,
+      "path": "talents/stormbringer.json",
+      "role": "hub",
+      "sha256": "b465ecb1003453750e9b2f41c1c7f7e9619b9eacbc904ea87cd8f0ea95143d13"
+    },
+    {
+      "bytes": 103497,
+      "path": "talents/sun-cleric.json",
+      "role": "hub",
+      "sha256": "42b8181b42cc3d4427c64e5a7db73fe6a305378aa6abe401b4b7c1cef807f8f5"
+    },
+    {
+      "bytes": 81218,
+      "path": "talents/templar.json",
+      "role": "hub",
+      "sha256": "64c83385e047c78722357ead1b2a2b80b9d2c5ba41e55b4fd8e4421cb97ae455"
+    },
+    {
+      "bytes": 85433,
+      "path": "talents/tinker.json",
+      "role": "hub",
+      "sha256": "1af391edb0139af435a23d120bfda5312416308bc01581dfcd0290527d8375b5"
+    },
+    {
+      "bytes": 106384,
+      "path": "talents/venomancer.json",
+      "role": "hub",
+      "sha256": "67998413844a93c18f94cbf65b43a57e4768aacb1c6bff0cdbd13dd4e7a88ec5"
+    },
+    {
+      "bytes": 85682,
+      "path": "talents/witch-doctor.json",
+      "role": "hub",
+      "sha256": "3bf70a61c65298f898793d708ddcd58d09210dce0b7b9f9b967bd4250ed679c2"
+    },
+    {
+      "bytes": 98105,
+      "path": "talents/witch-hunter.json",
+      "role": "hub",
+      "sha256": "b080695f224bd8096c64e204ff4a03288cc3a5cb8efe38c44ed79d0c50eba8d6"
+    }
+  ],
+  "summary": {
+    "ca_entries": 10255,
+    "community_edges": {
+      "candidate_not_runtime_edge": 142,
+      "candidates_same_ca_class_tab": 134,
+      "dangling_community_node": 8,
+      "present_runtime_edge": 4809,
+      "unmapped_or_ambiguous": 43
+    },
+    "description_enrichment_rows": 3600,
+    "master_absent_from_ca": 1571,
+    "master_any_rank_overlap": 3601,
+    "master_ids": 5172,
+    "runtime_edges": 5597,
+    "skill_files": 21,
+    "skill_rows": 2909,
+    "talent_files": 21,
+    "talent_nodes": 3612
+  },
+  "upstream_revision": {
+    "status": "asserted_not_verified",
+    "value": "664f2768f0695187349fc38842eae6a1588cc352"
+  }
+}

--- a/contrib/CoADataComparison/test_compare_ca.py
+++ b/contrib/CoADataComparison/test_compare_ca.py
@@ -1,0 +1,172 @@
+"""Synthetic-only CLI contract tests; no corpus or third-party imports."""
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+CLI = Path(__file__).resolve().with_name('compare_ca.py')
+
+
+class ComparisonTests(unittest.TestCase):
+    def setUp(self):
+        # Retained temporary fixtures: the workspace forbids unapproved deletion.
+        self.base = Path(tempfile.mkdtemp(prefix='comparison synthetic spaces '))
+        self.ca = self.base / 'ca input'
+        self.hub = self.base / 'hub input'
+        self.ca.mkdir()
+        self.hub.mkdir()
+        self.out = self.base / 'report.json'
+        self.entries = [dict(ID=i, SpellID=s, SpellID2=0, SpellID3=0,
+                             SpellID4=0, SpellID5=0, ClassTypeID=c, TabTypeID=1,
+                             Description='', Description2='', Name='PRIVATE SENTINEL')
+                        for i, s, c in [(1, 10, 1), (2, 20, 1), (3, 30, 2),
+                                        (4, 40, 1), (5, 40, 1)]]
+        self.entries[0]['SpellID2'] = 11
+        self.nodes = [dict(id='1-1-0-0', spellId=10, dependencies=['1-1-1-0', '1-1-2-0', '1-1-3-0', '1-1-9-0']),
+                      dict(id='1-1-1-0', spellId=20, dependencies=['1-1-0-0']),
+                      dict(id='1-1-2-0', spellId=30), dict(id='1-1-3-0', spellId=40),
+                      dict(id='1-1-4-0a', spellId=11)]
+        self.put(self.ca / 'entries.json', self.entries)
+        self.put(self.ca / 'edges.json', {'1': [2]})
+        self.put(self.hub / 'classes.json', [dict(id=1, slug='synthetic')])
+        self.put(self.hub / 'skills/synthetic.json', dict(classId=1, count=1, skills=[dict(id=10)]))
+        self.put(self.hub / 'talents/synthetic.json', dict(nodeCount=5, trees=[dict(tabId=1, nodeCount=5, nodes=self.nodes)]))
+        self.put(self.hub / 'spells/master_index.json', [dict(id=i, description='PRIVATE SENTINEL') for i in [10, 11, 20, 99]])
+
+    def put(self, path, data):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding='utf-8')
+
+    def run_cli(self, extra=()):
+        return subprocess.run([sys.executable, str(CLI), '--ca-root', str(self.ca),
+                               '--hub-root', str(self.hub), '--upstream-revision', 'a' * 40,
+                               '--output', str(self.out), *extra], cwd=self.base,
+                              capture_output=True, text=True)
+
+    def test_numeric_comparison_privacy_and_determinism(self):
+        result = self.run_cli()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        raw = self.out.read_bytes()
+        report = json.loads(raw)
+        self.assertEqual(report['summary']['master_ids'], 4)
+        self.assertEqual(report['summary']['master_any_rank_overlap'], 3)
+        self.assertEqual(report['summary']['master_absent_from_ca'], 1)
+        self.assertEqual(report['summary']['description_enrichment_rows'], 2)
+        self.assertEqual(report['master_absent_ids'], [99])
+        self.assertEqual(report['description_candidates'], [{'ca_id': 1, 'spell_id': 10}, {'ca_id': 2, 'spell_id': 20}])
+        self.assertEqual(report['summary']['community_edges'], dict(present_runtime_edge=1,
+                         candidate_not_runtime_edge=2, candidates_same_ca_class_tab=1,
+                         unmapped_or_ambiguous=1, dangling_community_node=1))
+        self.assertEqual(report['upstream_revision'], {'value': 'a' * 40, 'status': 'asserted_not_verified'})
+        self.assertEqual(len(report['edge_hypotheses']), 5)
+        self.assertEqual(report['sources'][0]['sha256'], hashlib.sha256((self.ca / 'edges.json').read_bytes()).hexdigest())
+        self.assertNotIn('PRIVATE SENTINEL', raw.decode() + result.stdout + result.stderr)
+        self.assertNotIn(str(self.base), raw.decode() + result.stdout + result.stderr)
+        self.out = self.base / 'second.json'
+        self.assertEqual(self.run_cli().returncode, 0)
+        self.assertEqual(raw, self.out.read_bytes())
+
+    def assert_rejected(self, extra=()):
+        result = self.run_cli(extra)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.out.exists())
+        self.assertNotIn('PRIVATE SENTINEL', result.stdout + result.stderr)
+        self.assertNotIn(str(self.base), result.stdout + result.stderr)
+        self.assertNotIn('Traceback', result.stderr)
+
+    def test_reject_invalid_ids_schema_and_counts(self):
+        cases = [
+            ('entries.json', [dict(self.entries[0], ID=True)]),
+            ('entries.json', [dict(self.entries[0], ID='1')]),
+            ('entries.json', [dict(self.entries[0], SpellID=1.0)]),
+            ('entries.json', [dict(self.entries[0], SpellID=-1)]),
+            ('entries.json', self.entries + [self.entries[0]]),
+            ('entries.json', {}),
+            ('entries.json', [dict(ID=1)]),
+            ('edges.json', {'01': [2]}),
+            ('edges.json', {'1': ['2']}),
+            ('edges.json', {'1': [True]}),
+            ('edges.json', {'1': [2, 2]}),
+            ('classes.json', [dict(id=1, slug='../PRIVATE SENTINEL')]),
+            ('classes.json', [dict(id=1, slug='C:\\PRIVATE SENTINEL')]),
+            ('classes.json', [dict(id=1, slug='synthetic'), dict(id=1, slug='synthetic')]),
+            ('skills/synthetic.json', dict(classId=1, count=2, skills=[dict(id=10)])),
+            ('skills/synthetic.json', dict(classId=1, count=2, skills=[dict(id=10), dict(id=10)])),
+            ('talents/synthetic.json', dict(nodeCount=9, trees=[])),
+            ('talents/synthetic.json', dict(nodeCount=1, trees=[dict(tabId=1, nodeCount=2, nodes=[self.nodes[0]])])),
+            ('talents/synthetic.json', dict(nodeCount=2, trees=[dict(tabId=1, nodeCount=2, nodes=[self.nodes[0], self.nodes[0]])])),
+            ('talents/synthetic.json', dict(nodeCount=1, trees=[dict(tabId=1, nodeCount=1, nodes=[dict(id='1-1-0-0A', spellId=10)])])),
+            ('talents/synthetic.json', dict(nodeCount=1, trees=[dict(tabId=1, nodeCount=1, nodes=[dict(id='1-1-0-0aa', spellId=10)])])),
+            ('spells/master_index.json', [dict(id=1), dict(id=1)]),
+            ('spells/master_index.json', [dict(id=False)]),
+            ('spells/master_index.json', [dict(id=1, description=42)]),
+        ]
+        for relative, data in cases:
+            with self.subTest(relative=relative, case=cases.index((relative, data))):
+                self.setUp()
+                root = self.ca if relative in ('entries.json', 'edges.json') else self.hub
+                self.put(root / relative, data)
+                self.assert_rejected()
+
+    def test_duplicate_json_keys_nonfinite_and_missing_files(self):
+        for raw in ['[{"id":1,"id":2}]', '[{"id":1,"description":NaN}]', '{', '[' * 1100 + ']' * 1100]:
+            with self.subTest(raw=raw):
+                self.setUp()
+                (self.hub / 'spells/master_index.json').write_text(raw, encoding='utf-8')
+                self.assert_rejected()
+        self.setUp()
+        (self.hub / 'spells/master_index.json').rename(self.hub / 'spells/retained.json')
+        self.assert_rejected()
+
+    def test_revision_and_argument_privacy(self):
+        for revision in ['a' * 39, 'g' * 40, 'PRIVATE SENTINEL']:
+            with self.subTest(revision=revision):
+                self.assert_rejected(['--upstream-revision', revision])
+        self.assert_rejected(['--PRIVATE SENTINEL', str(self.base)])
+
+    def test_runtime_empty_source_dangling_is_preserved(self):
+        self.put(self.ca / 'edges.json', {'1': [99], '98': []})
+        result = self.run_cli()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(self.out.read_text())
+        self.assertEqual(report['runtime_dangling_source_ids'], [98])
+        self.assertEqual(report['runtime_dangling_target_ids'], [99])
+
+    def test_input_bytes_unchanged_and_unlisted_files_ignored(self):
+        self.put(self.hub / 'unlisted.json', {'private': 'PRIVATE SENTINEL'})
+        before = {str(p): p.read_bytes() for root in (self.ca, self.hub) for p in root.rglob('*.json')}
+        self.assertEqual(self.run_cli().returncode, 0)
+        self.assertEqual(before, {p: Path(p).read_bytes() for p in before})
+        report = json.loads(self.out.read_text())
+        ambiguous = [e for e in report['edge_hypotheses'] if e['status'] == 'unmapped_or_ambiguous']
+        self.assertEqual(ambiguous[0]['target_ca_ids'], [4, 5])
+        cross = [e for e in report['edge_hypotheses'] if e['status'] == 'candidate_not_runtime_edge' and not e['same_ca_class_tab']]
+        self.assertEqual(cross[0]['target_ca_ids'], [3])
+        self.assertEqual(len(report['sources']), 6)
+
+    def test_output_symlink_is_not_a_new_file(self):
+        target = self.base / 'absent-target.json'
+        try:
+            self.out.symlink_to(target)
+        except OSError:
+            self.skipTest('symlinks unavailable for this test account')
+        result = self.run_cli()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(target.exists())
+        self.assertTrue(self.out.is_symlink())
+
+    def test_output_cannot_overwrite_or_enter_input_roots(self):
+        self.out.write_text('preserve', encoding='utf-8')
+        result = self.run_cli()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.out.read_text(), 'preserve')
+        for root in [self.ca, self.hub]:
+            self.out = root / 'new-output.json'
+            self.assert_rejected()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/edges_import.py
+++ b/tools/edges_import.py
@@ -51,7 +51,8 @@ def lua_block(src, key):
 def load_edges():
     if not os.path.exists(SV):
         raise SystemExit("missing %s" % SV)
-    src = io.open(SV, encoding="utf-8", errors="replace").read()
+    with io.open(SV, encoding="utf-8", errors="replace") as f:
+        src = f.read()
     block = lua_block(src, "edges")
     edges = {}
     for m in re.finditer(r'\["(\d+)"\] = \{(.*?)\n\t\t\}', block, re.S):
@@ -92,14 +93,16 @@ def validate(edges, rows):
     ok &= recip == 0
 
     if not rows:
-        print("entries.csv missing -- skipping the direction / boundary checks")
-        return ok
+        print("entries.csv missing or empty -- cannot validate direction / boundary checks")
+        return False
 
     dy = collections.Counter()
     cross = 0
     for a, vs in edges.items():
         ra = rows.get(a)
         if not ra:
+            print("missing source in entries.csv: %d" % a)
+            ok = False
             continue
         for b in vs:
             rb = rows.get(b)
@@ -129,7 +132,7 @@ def main():
     ok = validate(edges, load_entries())
     if "--check" in sys.argv[1:]:
         print("check only -- nothing written")
-    else:
+    elif ok:
         with io.open(OUT, "w", encoding="utf-8") as f:
             json.dump({str(k): edges[k] for k in sorted(edges)}, f,
                       indent=0, sort_keys=True)

--- a/tools/test_edges_import.py
+++ b/tools/test_edges_import.py
@@ -1,0 +1,159 @@
+"""Synthetic regressions for edges_import; never use client/export data."""
+
+import contextlib
+import gc
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import warnings
+from unittest import mock
+
+
+# Load only the pure importer, not other tools or server modules.
+spec = importlib.util.spec_from_file_location(
+    "edges_import", os.path.join(os.path.dirname(__file__), "edges_import.py"))
+edges_import = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(edges_import)
+
+
+class EdgesImportTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        paths = {name: os.path.join(self.temp.name, filename) for name, filename in
+                 (("SV", "synthetic.lua"), ("ENTRIES", "entries.csv"),
+                  ("OUT", "edges.json"))}
+        patcher = mock.patch.multiple(edges_import, **paths)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.write_edges({2: [1]})
+        self.write_entries("1,0,1,1\n2,1,1,1\n")
+
+    def write_edges(self, edges):
+        with io.open(edges_import.SV, "w", encoding="utf-8") as f:
+            f.write('CoAReaderDB = {\n\t["edges"] = {\n')
+            for node, targets in edges.items():
+                f.write('\t\t["%d"] = {\n' % node)
+                for target in targets:
+                    f.write('\t\t\t%d,\n' % target)
+                f.write('\t\t},\n')
+            f.write('\t},\n}\n')
+
+    def write_entries(self, rows):
+        with io.open(edges_import.ENTRIES, "w", encoding="utf-8") as f:
+            f.write("ID,PositionY,ClassType,TabType\n" + rows)
+
+    def run_main(self, check=False):
+        output = io.StringIO()
+        argv = ["edges_import.py"] + (["--check"] if check else [])
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output):
+            result = edges_import.main()
+        return result, output.getvalue()
+
+    def test_valid_graph_writes_exact_edges(self):
+        result, output = self.run_main()
+        self.assertEqual(result, 0)
+        with io.open(edges_import.OUT, encoding="utf-8") as f:
+            self.assertEqual(json.load(f), {"2": [1]})
+        self.assertIn("wrote ", output)
+
+    def test_loading_edges_closes_source_file(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ResourceWarning)
+            self.assertEqual(edges_import.load_edges(), {2: [1]})
+            gc.collect()
+        self.assertFalse([w for w in caught if issubclass(w.category, ResourceWarning)])
+
+    def test_check_never_creates_or_replaces_output(self):
+        for rows, expected in (("1,0,1,1\n2,1,1,1\n", 0),
+                               ("1,0,2,1\n2,1,1,1\n", 1)):
+            with self.subTest(expected=expected):
+                self.write_entries(rows)
+                with mock.patch.object(edges_import, "OUT",
+                                       os.path.join(self.temp.name, str(expected))):
+                    result, output = self.run_main(check=True)
+                    self.assertEqual(result, expected)
+                    self.assertFalse(os.path.exists(edges_import.OUT))
+                    with io.open(edges_import.OUT, "w", encoding="utf-8") as f:
+                        f.write("unchanged")
+                    result, output = self.run_main(check=True)
+                    self.assertEqual(result, expected)
+                    with io.open(edges_import.OUT, encoding="utf-8") as f:
+                        self.assertEqual(f.read(), "unchanged")
+                    self.assertIn("check only -- nothing written", output)
+
+    def test_documented_dangling_targets_are_diagnostics_not_failure(self):
+        # SCHEMA.md documents these targets as absent, not invalid sources.
+        edges = {2: [1, 6451, 7181, 17567]}
+        self.write_edges(edges)
+        for check in (True, False):
+            result, output = self.run_main(check)
+            self.assertEqual(result, 0)
+            self.assertIn("dangling targets (drop on import): [6451, 7181, 17567]",
+                          output)
+        with io.open(edges_import.OUT, encoding="utf-8") as f:
+            self.assertEqual(json.load(f), {"2": edges[2]})
+
+    def test_existing_invariants_still_reject_invalid_graphs(self):
+        for name, edges, rows in (
+                ("reciprocal", {2: [1], 1: [2, 3]}, "1,0,1,1\n2,0,1,1\n3,0,1,1\n"),
+                ("downward", {2: [1], 3: [2]}, "1,0,1,1\n2,1,1,1\n3,0,1,1\n"),
+                ("tab", {2: [1]}, "1,0,1,2\n2,1,1,1\n"),
+                ("nonzero root", {2: [1]}, "1,1,1,1\n2,2,1,1\n")):
+            with self.subTest(name=name):
+                self.write_edges(edges)
+                self.write_entries(rows)
+                result, output = self.run_main()
+                self.assertEqual(result, 1)
+                self.assertFalse(os.path.exists(edges_import.OUT))
+
+    def test_missing_input_file_fails_without_writing(self):
+        with mock.patch.object(edges_import, "SV",
+                               os.path.join(self.temp.name, "absent.lua")):
+            with self.assertRaisesRegex(SystemExit, "missing "):
+                self.run_main()
+        self.assertFalse(os.path.exists(edges_import.OUT))
+
+    def test_missing_source_row_fails_without_writing(self):
+        self.write_edges({2: [1], 3: [1]})
+        for check in (False, True):
+            with self.subTest(check=check):
+                result, output = self.run_main(check)
+                self.assertEqual(result, 1)
+                self.assertFalse(os.path.exists(edges_import.OUT))
+                self.assertIn("missing source", output)
+
+    def test_missing_or_empty_entries_fail_without_writing(self):
+        for filename, contents in (("absent.csv", None), ("empty.csv", ""),
+                                   ("header.csv", "ID,PositionY,ClassType,TabType\n")):
+            with self.subTest(filename=filename):
+                path = os.path.join(self.temp.name, filename)
+                if contents is not None:
+                    with io.open(path, "w", encoding="utf-8") as f:
+                        f.write(contents)
+                with mock.patch.object(edges_import, "ENTRIES", path):
+                    for check in (False, True):
+                        result, output = self.run_main(check)
+                        self.assertEqual(result, 1)
+                        self.assertFalse(os.path.exists(edges_import.OUT))
+
+    def test_invalid_graph_does_not_create_or_replace_output(self):
+        self.write_entries("1,0,2,1\n2,1,1,1\n")
+        result, output = self.run_main()
+        self.assertEqual(result, 1)
+        self.assertFalse(os.path.exists(edges_import.OUT))
+        with io.open(edges_import.OUT, "w", encoding="utf-8") as f:
+            f.write("preserve existing bytes\n")
+        result, output = self.run_main()
+        self.assertEqual(result, 1)
+        with io.open(edges_import.OUT, encoding="utf-8") as f:
+            self.assertEqual(f.read(), "preserve existing bytes\n")
+        self.assertNotIn("wrote ", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Optional research contribution. Not part of the runnable server stack.

- `contrib/CoADataComparison/` compares locally supplied Character-Advancement exports with a locally held CoA Build Hub archive. It reports identifier overlap, description *availability*, source hashes, and community-versus-runtime dependency hypotheses. It does not copy descriptions, tooltips, icons, client files, or machine paths into the report, and it does not rewrite either dataset.
- `tools/edges_import.py` no longer writes when validation fails. Missing/empty `entries.csv` and missing source rows fail closed. The three documented dangling targets remain diagnostics, not invented edges. Synthetic tests are in `tools/test_edges_import.py`.

No client MPQs, DBCs, caches, credentials, or bulk Hub text are included.

## Test plan

From the repository root, Python 3.11+:

```
python -m unittest discover -s contrib/CoADataComparison -p "test_*.py" -v
python -B tools/test_edges_import.py -v
```

These use synthetic fixtures only. Real Hub/CA data stays on the contributor's machine.

Please review before marking ready to merge. This PR is opened as a **draft** so it remains visible without implying it should be merged as-is.